### PR TITLE
add AlreadyExists exception

### DIFF
--- a/src/cfn_resource/exceptions.py
+++ b/src/cfn_resource/exceptions.py
@@ -32,7 +32,7 @@ class Codes:
     # the customer has insufficient permissions to perform this action
     ACCESS_DENIED = "AccessDenied"
     # a generic exception caused by invalid input from the customer
-    INVALID_REQUEST = 'InvalidRequest'
+    INVALID_REQUEST = "InvalidRequest"
     # a resource create request failed for an existing entity (only applicable to
     # CreateHandler) Handlers MUST return this error when duplicate creation requests
     # are received.


### PR DESCRIPTION
adds `AlreadyExists` exception to bring up to date with what's available in https://github.com/aws-cloudformation/aws-cloudformation-rpdk-java-plugin/blob/master/src/main/java/com/amazonaws/cloudformation/proxy/HandlerErrorCode.java


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
