### PR TITLE
fixes python version for Python36LanguagePlugin entrypoint

### DIFF
--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -14,8 +14,8 @@ OLD_PATH = []
 
 class Python36LanguagePlugin(LanguagePlugin):
     MODULE_NAME = __name__
-    NAME = "python37"
-    RUNTIME = "python3.7"
+    NAME = "python36"
+    RUNTIME = "python3.6"
     ENTRY_POINT = "cfn_resource.handler_wrapper._handler_wrapper"
     CODE_URI = "./target/{}.zip"
 


### PR DESCRIPTION
fix bug where selecting python 3.6 would give you a 3.7 environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
