### PR TITLE
Add PENDING OperationStatus and tests

### DIFF
--- a/src/aws_cloudformation_rpdk_python_lib/interface.py
+++ b/src/aws_cloudformation_rpdk_python_lib/interface.py
@@ -25,6 +25,7 @@ class Action(str, _AutoName):
 
 
 class OperationStatus(str, _AutoName):
+    PENDING = auto()
     IN_PROGRESS = auto()
     SUCCESS = auto()
     FAILED = auto()


### PR DESCRIPTION
*Issue #, if available:* #25 

*Description of changes:* A new member was added to the `OperationStatus` enum. Also add tests similar to the RPDK core to check the enums are in line with SDK models.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
