### PR TITLE
AlreadyExists/NotFound message to match Java plugin

### DIFF
--- a/src/aws_cloudformation_rpdk_python_lib/exceptions.py
+++ b/src/aws_cloudformation_rpdk_python_lib/exceptions.py
@@ -29,11 +29,19 @@ class InvalidCredentials(_HandlerError[T]):
 
 
 class AlreadyExists(_HandlerError[T]):
-    pass
+    def __init__(self, type_name: str, identifier: str):
+        super().__init__(
+            f"Resource of type '{type_name}' with identifier "
+            f"'{identifier}' already exists."
+        )
 
 
 class NotFound(_HandlerError[T]):
-    pass
+    def __init__(self, type_name: str, identifier: str):
+        super().__init__(
+            f"Resource of type '{type_name}' with identifier "
+            f"'{identifier}' was not found."
+        )
 
 
 class ResourceConflict(_HandlerError[T]):

--- a/tests/lib/exceptions_test.py
+++ b/tests/lib/exceptions_test.py
@@ -32,6 +32,10 @@ def test_all_error_codes_have_exceptions():
 
 @pytest.mark.parametrize("name, ex", EXCEPTIONS)
 def test_exception_to_progress_event(name, ex):
-    progress_event = ex().to_progress_event()
+    try:
+        e = ex()
+    except TypeError:
+        e = ex("Foo::Bar::Baz", "ident")
+    progress_event = e.to_progress_event()
     assert progress_event.status == OperationStatus.FAILED
     assert progress_event.errorCode == HandlerErrorCode[name]


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* The Java plugin implements a subset of handler error codes as exceptions ([ResourceAlreadyExistsException](https://github.com/aws-cloudformation/aws-cloudformation-rpdk-java-plugin/blob/94c61d3e172c43ea14cd0493500b41d67280b298/src/main/java/com/amazonaws/cloudformation/exceptions/ResourceAlreadyExistsException.java#L33), [ResourceNotFoundException](https://github.com/aws-cloudformation/aws-cloudformation-rpdk-java-plugin/blob/94c61d3e172c43ea14cd0493500b41d67280b298/src/main/java/com/amazonaws/cloudformation/exceptions/ResourceNotFoundException.java#L33)). These have predefined messages to ensure the the response exposed to the customer is uniform.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
