### PR TITLE
callbackContext should default None

### DIFF
--- a/src/aws_cloudformation_rpdk_python_lib/interface.py
+++ b/src/aws_cloudformation_rpdk_python_lib/interface.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any, Generic, List, Mapping, Optional, Type, TypeVar
 
@@ -55,7 +55,7 @@ class ProgressEvent(Generic[T]):
     status: OperationStatus
     errorCode: Optional[HandlerErrorCode] = None
     message: str = ""
-    callbackContext: Mapping[str, Any] = field(default_factory=dict)
+    callbackContext: Optional[Mapping[str, Any]] = None
     callbackDelaySeconds: int = 0
     resourceModel: Optional[T] = None
     resourceModels: Optional[List[T]] = None

--- a/tests/lib/interface_test.py
+++ b/tests/lib/interface_test.py
@@ -36,7 +36,6 @@ def test_progress_event_failed_is_json_serializable(error_code, message):
         "status": OperationStatus.FAILED.value,
         "errorCode": error_code.value,
         "message": message,
-        "callbackContext": {},
         "callbackDelaySeconds": 0,
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`cfn-cli test` asserts that `SUCCESS` events should not return a callback context. https://github.com/aws-cloudformation/aws-cloudformation-rpdk/blob/master/src/rpdk/core/contract/resource_client.py#L182-L184

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
