### PR TITLE
log delivery to CloudWatch Logs in provider account

### DIFF
--- a/src/aws_cloudformation_rpdk_python_lib/log_delivery.py
+++ b/src/aws_cloudformation_rpdk_python_lib/log_delivery.py
@@ -1,0 +1,84 @@
+import logging
+import time
+from typing import Any, Mapping
+
+# boto3 doesn't have stub files
+import boto3  # type: ignore
+
+
+class ProviderLogHandler(logging.Handler):
+    def __init__(self, group: str, stream: str, creds: Mapping[str, str]):
+        logging.Handler.__init__(self)
+        self.group = group
+        self.stream = stream.replace(":", "__")
+        self.client = boto3.client("logs", **creds)
+        self.sequence_token = ""
+
+    @classmethod
+    def setup(cls, event_data: Mapping[str, Any]) -> None:
+        log_creds = event_data.get("requestData", {}).get("providerCredentials", {})
+        log_group = event_data.get("requestData", {}).get("providerLogGroupName", "")
+        stream_prefix = event_data.get(
+            "stackId", f'{event_data.get("awsAccountId")}-{event_data.get("region")}'
+        )
+        stream_suffix = event_data.get("requestData", {}).get(
+            "logicalResourceId", event_data.get("action")
+        )
+        if log_creds and log_group:
+            log_handler = cls(
+                group=log_group,
+                stream=f"{stream_prefix}/{stream_suffix}",
+                creds={
+                    "aws_access_key_id": log_creds["accessKeyId"],
+                    "aws_secret_access_key": log_creds["secretAccessKey"],
+                    "aws_session_token": log_creds["sessionToken"],
+                },
+            )
+            logging.getLogger().addHandler(log_handler)
+
+    def _create_log_group(self) -> None:
+        try:
+            self.client.create_log_group(logGroupName=self.group)
+        except self.client.exceptions.ResourceAlreadyExistsException:
+            pass
+
+    def _create_log_stream(self) -> None:
+        try:
+            self.client.create_log_stream(
+                logGroupName=self.group, logStreamName=self.stream
+            )
+        except self.client.exceptions.ResourceAlreadyExistsException:
+            pass
+
+    def _put_log_event(self, msg: logging.LogRecord) -> None:
+        kwargs = {
+            "logGroupName": self.group,
+            "logStreamName": self.stream,
+            "logEvents": [
+                {
+                    "timestamp": int(round(time.time() * 1000)),
+                    "message": self.format(msg),
+                }
+            ],
+        }
+        if self.sequence_token:
+            kwargs["sequenceToken"] = self.sequence_token
+        try:
+            self.sequence_token = self.client.put_log_events(**kwargs)[
+                "nextSequenceToken"
+            ]
+        except (
+            self.client.exceptions.DataAlreadyAcceptedException,
+            self.client.exceptions.InvalidSequenceTokenException,
+        ) as e:
+            self.sequence_token = str(e).split(" ")[-1]
+            self._put_log_event(msg)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self._put_log_event(record)
+        except self.client.exceptions.ResourceNotFoundException as e:
+            if "log group does not exist" in str(e):
+                self._create_log_group()
+            self._create_log_stream()
+            self._put_log_event(record)

--- a/src/aws_cloudformation_rpdk_python_lib/resource.py
+++ b/src/aws_cloudformation_rpdk_python_lib/resource.py
@@ -12,6 +12,7 @@ from .interface import (
     ResourceHandlerRequest,
     T,
 )
+from .log_delivery import ProviderLogHandler
 from .utils import (
     Credentials,
     HandlerRequest,
@@ -144,6 +145,7 @@ class Resource(Generic[T]):
         self, event_data: MutableMapping[str, Any], _context: Any
     ) -> MutableMapping[str, Any]:
         try:
+            ProviderLogHandler.setup(event_data)
             parsed = self._parse_request(event_data)
             session, request, action, callback_context = parsed
             progress_event = self._invoke_handler(


### PR DESCRIPTION
*Issue #, if available:* #21 

*Description of changes:*

Enables simple log delivery to the provider account. 

Log stream names are created as `f"{arn.replace(':', '__')}/{LogicalResourceId}"` or `f"{CallerAccountId}-{region}/{action}` if arn or logical_id is not present in the request (suspect this is the case with `list` calls)

Doesn't do any batching/queuing of messages to cwl which would ensure ordering and handle throttles. this can be added in a future PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
