### PR TITLE
fix zip packaging

### DIFF
--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -162,9 +162,10 @@ def test_package_pip(project):
 
     with zip_path.open("rb") as f, ZipFile(f, mode="r") as zip_file:
         assert sorted(zip_file.namelist()) == [
-            "foo_bar_baz/__init__.py",
-            "foo_bar_baz/handlers.py",
-            "foo_bar_baz/models.py",
+            "ResourceProvider.zip",
+            "src/foo_bar_baz/__init__.py",
+            "src/foo_bar_baz/handlers.py",
+            "src/foo_bar_baz/models.py",
         ]
 
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

creates a nested zip as per other plugins where lambda deployment package is a zip.

In order to retain cfn-cli test functionality, dependencies are now placed into the src/ folder so that sam can execute against the folder instead of the zip. Not mad about this but it does not seem that sam allows multiple folders to be merged/bound into the container.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.