### PR TITLE
Set test entrypoint on project

### DIFF
--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -72,6 +72,9 @@ class Python36LanguagePlugin(LanguagePlugin):
 
         project.runtime = self.RUNTIME
         project.entrypoint = self.ENTRY_POINT.format(self.package_name)
+        project.test_entrypoint = project.entrypoint.replace(
+            ".resource", ".test_entrypoint"
+        )
 
         def _render_template(path, **kwargs):
             LOG.debug("Writing '%s'", path)
@@ -123,9 +126,7 @@ class Python36LanguagePlugin(LanguagePlugin):
                 "TypeFunction": handler_params,
                 "TestEntrypoint": {
                     **handler_params,
-                    "Handler": handler_params["Handler"].replace(
-                        ".resource", ".test_entrypoint"
-                    ),
+                    "Handler": project.test_entrypoint,
                 },
             },
         )


### PR DESCRIPTION
*Issue #, if available:* #31 

*Description of changes:* Currently, `testEntrypoint` in `.rpdk-config` is `null`:

```
{                             
    "typeName": "AWS::Foo::Bar",     
    "language": "python37",            
    "runtime": "python3.7",           
    "entrypoint": "aws_foo_bar.handlers.resource",          
    "testEntrypoint": null,          
    "settings": {                                                    
        "use_docker": true
    }                                                                     
}         
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
