### PR TITLE
Report progress

### DIFF
--- a/src/cloudformation_cli_python_lib/callback.py
+++ b/src/cloudformation_cli_python_lib/callback.py
@@ -1,0 +1,45 @@
+import json
+import logging
+from typing import Optional
+from uuid import uuid4
+
+# boto3 doesn't have stub files
+from boto3 import Session  # type: ignore
+
+from .interface import BaseResourceModel, HandlerErrorCode, OperationStatus
+from .utils import KitchenSinkEncoder
+
+LOG = logging.getLogger(__name__)
+
+
+def report_progress(  # pylint: disable=too-many-arguments
+    session: Session,
+    token: str,
+    code: Optional[HandlerErrorCode],
+    status: OperationStatus,
+    current_status: Optional[OperationStatus],
+    model: Optional[BaseResourceModel],
+    message: str,
+) -> None:
+    client = session.client("cloudformation")
+    request = {
+        "BearerToken": token,
+        "OperationStatus": status.name,
+        "StatusMessage": message,
+        "ClientRequestToken": str(uuid4()),
+    }
+    if model:
+        request["ResourceModel"] = json.dumps(
+            model._serialize(),  # pylint: disable=protected-access
+            cls=KitchenSinkEncoder,
+        )
+    if code:
+        request["ErrorCode"] = code
+    if current_status:
+        request["CurrentOperationStatus"] = current_status.name
+    response = client.record_handler_progress(**request)
+    LOG.info(
+        "Record Handler Progress with Request Id %s and Request: {%s}",
+        response["ResponseMetadata"]["RequestId"],
+        request,
+    )

--- a/src/cloudformation_cli_python_lib/callback.py
+++ b/src/cloudformation_cli_python_lib/callback.py
@@ -34,7 +34,7 @@ def report_progress(  # pylint: disable=too-many-arguments
             cls=KitchenSinkEncoder,
         )
     if code:
-        request["ErrorCode"] = code
+        request["ErrorCode"] = code.name
     if current_status:
         request["CurrentOperationStatus"] = current_status.name
     response = client.record_handler_progress(**request)

--- a/src/cloudformation_cli_python_lib/callback.py
+++ b/src/cloudformation_cli_python_lib/callback.py
@@ -14,29 +14,29 @@ LOG = logging.getLogger(__name__)
 
 def report_progress(  # pylint: disable=too-many-arguments
     session: Session,
-    token: str,
-    code: Optional[HandlerErrorCode],
-    status: OperationStatus,
-    current_status: Optional[OperationStatus],
-    model: Optional[BaseResourceModel],
-    message: str,
+    bearer_token: str,
+    error_code: Optional[HandlerErrorCode],
+    operation_status: OperationStatus,
+    current_operation_status: Optional[OperationStatus],
+    resource_model: Optional[BaseResourceModel],
+    status_message: str,
 ) -> None:
     client = session.client("cloudformation")
     request = {
-        "BearerToken": token,
-        "OperationStatus": status.name,
-        "StatusMessage": message,
+        "BearerToken": bearer_token,
+        "OperationStatus": operation_status.name,
+        "StatusMessage": status_message,
         "ClientRequestToken": str(uuid4()),
     }
-    if model:
+    if resource_model:
         request["ResourceModel"] = json.dumps(
-            model._serialize(),  # pylint: disable=protected-access
+            resource_model._serialize(),  # pylint: disable=protected-access
             cls=KitchenSinkEncoder,
         )
-    if code:
-        request["ErrorCode"] = code.name
-    if current_status:
-        request["CurrentOperationStatus"] = current_status.name
+    if error_code:
+        request["ErrorCode"] = error_code.name
+    if current_operation_status:
+        request["CurrentOperationStatus"] = current_operation_status.name
     response = client.record_handler_progress(**request)
     LOG.info(
         "Record Handler Progress with Request Id %s and Request: {%s}",

--- a/src/cloudformation_cli_python_lib/interface.py
+++ b/src/cloudformation_cli_python_lib/interface.py
@@ -100,10 +100,11 @@ class ProgressEvent:
                     model._serialize()
                     for model in self.resourceModels
                 ]
-            if ser.get("callbackDelaySeconds") or ser.get("callbackDelaySeconds") == 0:
-                del ser["callbackDelaySeconds"]
-            if ser.get("callbackContext"):
+            del ser["callbackDelaySeconds"]
+            if "callbackContext" in ser:
                 del ser["callbackContext"]
+            if self.errorCode:
+                ser["errorCode"] = self.errorCode.name
         return ser
 
     @classmethod

--- a/src/cloudformation_cli_python_lib/interface.py
+++ b/src/cloudformation_cli_python_lib/interface.py
@@ -90,9 +90,20 @@ class ProgressEvent:
         # mutate to what's expected in the response
         if to_response:
             ser["bearerToken"] = bearer_token
-            ser["operationStatus"] = ser.pop("status")
-            if ser["callbackDelaySeconds"] == 0:
+            ser["operationStatus"] = ser.pop("status").name
+            if self.resourceModel:
+                # pylint: disable=protected-access
+                ser["resourceModel"] = self.resourceModel._serialize()
+            if self.resourceModels:
+                ser["resourceModels"] = [
+                    # pylint: disable=protected-access
+                    model._serialize()
+                    for model in self.resourceModels
+                ]
+            if ser.get("callbackDelaySeconds") or ser.get("callbackDelaySeconds") == 0:
                 del ser["callbackDelaySeconds"]
+            if ser.get("callbackContext"):
+                del ser["callbackContext"]
         return ser
 
     @classmethod

--- a/src/cloudformation_cli_python_lib/interface.py
+++ b/src/cloudformation_cli_python_lib/interface.py
@@ -75,7 +75,7 @@ class ProgressEvent:
     status: OperationStatus
     errorCode: Optional[HandlerErrorCode] = None
     message: str = ""
-    callbackContext: Optional[Mapping[str, Any]] = None
+    callbackContext: Optional[MutableMapping[str, Any]] = None
     callbackDelaySeconds: int = 0
     resourceModel: Optional[BaseResourceModel] = None
     resourceModels: Optional[List[BaseResourceModel]] = None

--- a/src/cloudformation_cli_python_lib/scheduler.py
+++ b/src/cloudformation_cli_python_lib/scheduler.py
@@ -55,4 +55,4 @@ class CloudWatchScheduler:
         schedule_time = datetime.now() + timedelta(minutes=minutes)
         # add another minute, as per java implementation
         schedule_time = schedule_time + timedelta(minutes=1)
-        return schedule_time.strftime("cron('%M %H %d %m ? %Y')")
+        return schedule_time.strftime("cron(%M %H %d %m ? %Y)")

--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -43,7 +43,7 @@ class RequestData:
     logicalResourceId: str
     resourceProperties: Mapping[str, Any]
     systemTags: Mapping[str, Any]
-    stackTags: Mapping[str, Any]
+    stackTags: Optional[Mapping[str, Any]] = None
     callerCredentials: Optional[Credentials] = field(default=None)
     providerCredentials: Optional[Credentials] = field(default=None)
     previousResourceProperties: Optional[Mapping[str, Any]] = None

--- a/tests/lib/callback_test.py
+++ b/tests/lib/callback_test.py
@@ -1,0 +1,61 @@
+# pylint: disable=redefined-outer-name,protected-access
+from unittest.mock import Mock, patch
+from uuid import uuid4
+
+import boto3
+from cloudformation_cli_python_lib.callback import report_progress
+from cloudformation_cli_python_lib.interface import (
+    BaseResourceModel,
+    HandlerErrorCode,
+    OperationStatus,
+)
+
+
+class MockSession:
+    def __init__(self):
+        self._cfn = Mock(boto3.client("cloudformation"), autospec=True)
+        self._cfn.record_handler_progress.return_value = {
+            "ResponseMetadata": {"RequestId": "mock_request"}
+        }
+
+    def client(self, _name):
+        return self._cfn
+
+
+def test_report_progress_minimal():
+    session = MockSession()
+    uuid = uuid4()
+    with patch("cloudformation_cli_python_lib.callback.uuid4", return_value=uuid):
+        report_progress(
+            session, "123", None, OperationStatus.IN_PROGRESS, None, None, ""
+        )
+    session._cfn.record_handler_progress.assert_called_once_with(
+        BearerToken="123",
+        OperationStatus="IN_PROGRESS",
+        StatusMessage="",
+        ClientRequestToken=str(uuid),
+    )
+
+
+def test_report_progress_full():
+    session = MockSession()
+    uuid = uuid4()
+    with patch("cloudformation_cli_python_lib.callback.uuid4", return_value=uuid):
+        report_progress(
+            session,
+            "123",
+            HandlerErrorCode.InternalFailure,
+            OperationStatus.FAILED,
+            OperationStatus.IN_PROGRESS,
+            BaseResourceModel(),
+            "test message",
+        )
+    session._cfn.record_handler_progress.assert_called_once_with(
+        BearerToken="123",
+        OperationStatus="FAILED",
+        CurrentOperationStatus="IN_PROGRESS",
+        StatusMessage="test message",
+        ResourceModel="{}",
+        ErrorCode="InternalFailure",
+        ClientRequestToken=str(uuid),
+    )

--- a/tests/lib/interface_test.py
+++ b/tests/lib/interface_test.py
@@ -1,5 +1,6 @@
-# pylint: disable=protected-access,redefined-outer-name
+# pylint: disable=protected-access,redefined-outer-name,abstract-method
 import json
+from dataclasses import dataclass
 from string import ascii_letters
 
 import boto3
@@ -24,6 +25,12 @@ def client():
         aws_session_token="",
         region_name="us-east-1",
     )
+
+
+@dataclass
+class TestModel(BaseResourceModel):
+    somekey: str
+    someotherkey: str
 
 
 def test_base_resource_model__deserialize():
@@ -52,15 +59,48 @@ def test_progress_event_failed_is_json_serializable(error_code, message):
 
 
 @given(s.text(ascii_letters), s.text(ascii_letters))
-def test_progress_event_serialize_to_response(message, bearer_token):
+def test_progress_event_serialize_to_response_with_context(message, bearer_token):
     event = ProgressEvent(
-        status=OperationStatus.SUCCESS, message=message, callbackDelaySeconds=1
+        status=OperationStatus.SUCCESS, message=message, callbackContext={"a": "b"}
     )
 
     assert event._serialize(to_response=True, bearer_token=bearer_token) == {
         "operationStatus": OperationStatus.SUCCESS.name,  # pylint: disable=no-member
         "message": message,
         "bearerToken": bearer_token,
+    }
+
+
+@given(s.text(ascii_letters), s.text(ascii_letters))
+def test_progress_event_serialize_to_response_with_model(message, bearer_token):
+    model = TestModel("a", "b")
+    event = ProgressEvent(
+        status=OperationStatus.SUCCESS, message=message, resourceModel=model
+    )
+
+    assert event._serialize(to_response=True, bearer_token=bearer_token) == {
+        "operationStatus": OperationStatus.SUCCESS.name,  # pylint: disable=no-member
+        "message": message,
+        "bearerToken": bearer_token,
+        "resourceModel": {"somekey": "a", "someotherkey": "b"},
+    }
+
+
+@given(s.text(ascii_letters), s.text(ascii_letters))
+def test_progress_event_serialize_to_response_with_models(message, bearer_token):
+    models = [TestModel("a", "b"), TestModel("c", "d")]
+    event = ProgressEvent(
+        status=OperationStatus.SUCCESS, message=message, resourceModels=models
+    )
+
+    assert event._serialize(to_response=True, bearer_token=bearer_token) == {
+        "operationStatus": OperationStatus.SUCCESS.name,  # pylint: disable=no-member
+        "message": message,
+        "bearerToken": bearer_token,
+        "resourceModels": [
+            {"somekey": "a", "someotherkey": "b"},
+            {"somekey": "c", "someotherkey": "d"},
+        ],
     }
 
 

--- a/tests/lib/interface_test.py
+++ b/tests/lib/interface_test.py
@@ -58,10 +58,9 @@ def test_progress_event_serialize_to_response(message, bearer_token):
     )
 
     assert event._serialize(to_response=True, bearer_token=bearer_token) == {
-        "operationStatus": OperationStatus.SUCCESS.value,
+        "operationStatus": OperationStatus.SUCCESS.name,  # pylint: disable=no-member
         "message": message,
         "bearerToken": bearer_token,
-        "callbackDelaySeconds": 1,
     }
 
 

--- a/tests/lib/resource_test.py
+++ b/tests/lib/resource_test.py
@@ -94,7 +94,7 @@ def test_entrypoint_success():
     assert event == {
         "message": "",
         "bearerToken": "123456",
-        "operationStatus": OperationStatus.SUCCESS,
+        "operationStatus": OperationStatus.SUCCESS.name,  # pylint: disable=no-member
     }
 
     mock_handler.assert_called_once()

--- a/tests/lib/resource_test.py
+++ b/tests/lib/resource_test.py
@@ -82,10 +82,13 @@ def test_entrypoint_success():
 
     with patch(
         "cloudformation_cli_python_lib.resource.ProviderLogHandler.setup"
-    ) as mock_log_delivery:
+    ) as mock_log_delivery, patch(
+        "cloudformation_cli_python_lib.resource.report_progress", autospec=True
+    ) as mock_report_progress:
         event = resource.__call__.__wrapped__(  # pylint: disable=no-member
             resource, ENTRYPOINT_PAYLOAD, None
         )
+    assert mock_report_progress.call_count == 2
     mock_log_delivery.assert_called_once()
 
     assert event == {
@@ -111,7 +114,9 @@ def test_entrypoint_success_without_caller_provider_creds():
         "operationStatus": OperationStatus.SUCCESS,
     }
 
-    with patch("cloudformation_cli_python_lib.resource.ProviderLogHandler.setup"):
+    with patch(
+        "cloudformation_cli_python_lib.resource.ProviderLogHandler.setup"
+    ), patch("cloudformation_cli_python_lib.resource.report_progress", autospec=True):
         # Credentials are defined in payload, but null
         payload["requestData"]["providerCredentials"] = None
         payload["requestData"]["callerCredentials"] = None

--- a/tests/lib/scheduler_test.py
+++ b/tests/lib/scheduler_test.py
@@ -131,4 +131,4 @@ def test_cleanup_cloudwatch_events_boto_error(mock_logger, mock_boto3_session):
 def test__min_to_cron(mock_datetime):
     mock_datetime.now.return_value = datetime.fromisoformat("2019-01-01 01:01:01")
     cron = CloudWatchScheduler._min_to_cron(1)
-    assert cron == "cron('03 01 01 01 ? 2019')"
+    assert cron == "cron(03 01 01 01 ? 2019)"


### PR DESCRIPTION
*Issue #, if available:* Also fixed #60 

*Description of changes:*

completes support for async handlers. I've end-to-end tested async CREATE using both local and cloudwatch reinvocations.

I optimised for getting this pr in as quickly as possible, over making the code pristine. This gets the plugin fully functional and can iterate/improve from here as we go.
  
Also fixes a few small bug that were exposed during testing:

* properly serialize `ProgressEvent` responses (was getting `Internal Failure` errors)
* log_delivery was creating duplicate handlers (duplicate messages delivered) when lambda re-used a container
* cloudwatch rules/targets were not being cleaned up

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
