### PR TITLE
Catch ConnectionError when Docker isn't running

### DIFF
--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -9,6 +9,7 @@ from zipfile import ZipFile
 import pytest
 
 from docker.errors import APIError, ContainerError, ImageLoadError
+from requests.exceptions import ConnectionError as RequestsConnectionError
 from rpdk.core.exceptions import DownstreamError
 from rpdk.core.project import Project
 from rpdk.python.codegen import (
@@ -252,6 +253,9 @@ def test__docker_build_good_path(plugin, tmp_path):
         lambda: ContainerError("abcde", 255, "/bin/false", "image", ""),
         ImageLoadError,
         lambda: APIError("500"),
+        lambda: RequestsConnectionError(
+            "Connection aborted.", ConnectionRefusedError(61, "Connection refused")
+        ),
     ],
 )
 def test__docker_build_bad_path(plugin, tmp_path, exception):


### PR DESCRIPTION
*Issue #, if available:* #56 

*Description of changes:* See issue. Error message is now:

```
$ cfn submit --dry-run
Starting Docker build. This may take several minutes if the image 'lambci/lambda:build-python3.7' needs to be pulled first.
=== Caught downstream error ===
Could not connect to docker - is it running?
---
If debugging indicates this is a possible error with this program,
please report the issue to the team and include the log file 'rpdk.log'.
Issue tracker: https://github.com/aws-cloudformation/aws-cloudformation-rpdk/issues
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
