### PR TITLE
implement CloudWatch metrics

### DIFF
--- a/src/cloudformation_cli_python_lib/resource.py
+++ b/src/cloudformation_cli_python_lib/resource.py
@@ -217,7 +217,7 @@ class Resource:
 
     # TODO: refactor to reduce branching and locals
     @_ensure_serialize  # noqa: C901
-    def __call__(  # pylint: disable=too-many-locals
+    def __call__(  # pylint: disable=too-many-locals  # noqa: C901
         self, event_data: MutableMapping[str, Any], context: LambdaContext
     ) -> MutableMapping[str, Any]:
         try:

--- a/src/cloudformation_cli_python_lib/resource.py
+++ b/src/cloudformation_cli_python_lib/resource.py
@@ -256,8 +256,8 @@ class Resource:
                 )
             invoke = True
             while invoke:
-                metrics.publish_invocation_metric(datetime.now(), action)
-                start_time = datetime.now()
+                metrics.publish_invocation_metric(datetime.utcnow(), action)
+                start_time = datetime.utcnow()
                 error = None
                 try:
                     progress = self._invoke_handler(
@@ -265,10 +265,10 @@ class Resource:
                     )
                 except Exception as e:  # pylint: disable=broad-except
                     error = e
-                m_secs = (datetime.now() - start_time).total_seconds() * 1000.0
-                metrics.publish_duration_metric(datetime.now(), action, m_secs)
+                m_secs = (datetime.utcnow() - start_time).total_seconds() * 1000.0
+                metrics.publish_duration_metric(datetime.utcnow(), action, m_secs)
                 if error:
-                    metrics.publish_exception_metric(datetime.now(), action, error)
+                    metrics.publish_exception_metric(datetime.utcnow(), action, error)
                     raise error
                 if progress.callbackContext:
                     callback = progress.callbackContext

--- a/src/cloudformation_cli_python_lib/resource.py
+++ b/src/cloudformation_cli_python_lib/resource.py
@@ -195,15 +195,13 @@ class Resource:
                 aws_secret_access_key=platform_creds.secretAccessKey,
                 aws_session_token=platform_creds.sessionToken,
             )
-            provider_sess = (
-                boto3.Session(
+            provider_sess = None
+            if provider_creds:
+                provider_sess = boto3.Session(
                     aws_access_key_id=provider_creds.accessKeyId,
                     aws_secret_access_key=provider_creds.secretAccessKey,
                     aws_session_token=provider_creds.sessionToken,
                 )
-                if provider_creds
-                else None
-            )
             action = Action[event.action]
             callback_context = event.requestContext.get("callbackContext", {})
         except Exception as e:  # pylint: disable=broad-except

--- a/tests/lib/resource_test.py
+++ b/tests/lib/resource_test.py
@@ -1,4 +1,5 @@
 # pylint: disable=redefined-outer-name,protected-access
+from dataclasses import dataclass
 from datetime import datetime
 from unittest.mock import Mock, call, patch, sentinel
 
@@ -6,6 +7,7 @@ import pytest
 from cloudformation_cli_python_lib.exceptions import InvalidRequest
 from cloudformation_cli_python_lib.interface import (
     Action,
+    BaseResourceModel,
     HandlerErrorCode,
     OperationStatus,
     ProgressEvent,
@@ -102,7 +104,15 @@ def test_entrypoint_success():
 
 
 def test_entrypoint_handler_raises():
-    resource = Resource(Mock())
+    @dataclass
+    class ResourceModel(BaseResourceModel):
+        a_string: str
+
+        @classmethod
+        def _deserialize(cls, json_data):
+            return cls("test")
+
+    resource = Resource(Mock(), ResourceModel)
 
     with patch(
         "cloudformation_cli_python_lib.resource.ProviderLogHandler.setup"

--- a/tests/lib/resource_test.py
+++ b/tests/lib/resource_test.py
@@ -101,6 +101,32 @@ def test_entrypoint_success():
     mock_handler.assert_called_once()
 
 
+def test_entrypoint_handler_raises():
+    resource = Resource(Mock())
+
+    with patch(
+        "cloudformation_cli_python_lib.resource.ProviderLogHandler.setup"
+    ), patch(
+        "cloudformation_cli_python_lib.resource.report_progress", autospec=True
+    ), patch(
+        "cloudformation_cli_python_lib.resource.MetricsPublisherProxy"
+    ) as mock_metrics, patch(
+        "cloudformation_cli_python_lib.resource.Resource._invoke_handler"
+    ) as mock__invoke_handler:
+        mock__invoke_handler.side_effect = InvalidRequest("handler failed")
+        event = resource.__call__.__wrapped__(  # pylint: disable=no-member
+            resource, ENTRYPOINT_PAYLOAD, None
+        )
+
+    mock_metrics.return_value.publish_exception_metric.assert_called_once()
+    assert event == {
+        "errorCode": "InvalidRequest",
+        "message": "handler failed",
+        "bearerToken": "123456",
+        "operationStatus": "FAILED",
+    }
+
+
 def test_entrypoint_non_mutating_action():
     payload = ENTRYPOINT_PAYLOAD.copy()
     payload["action"] = "READ"
@@ -204,11 +230,11 @@ def test__parse_request_valid_request():
         "cloudformation_cli_python_lib.resource.boto3.Session"
     ) as mock_platform_session:
         ret = resource._parse_request(ENTRYPOINT_PAYLOAD)
-    caller_sess, platform_sess, request, action, callback_context, _event = ret
-
+    sessions, request, action, callback_context, _event = ret
+    caller_sess, _, platform_sess = sessions
     mock_caller_session.assert_called_once()
     assert caller_sess is mock_caller_session.return_value
-    mock_platform_session.assert_called_once()
+    assert mock_platform_session.call_count == 2
     assert platform_sess is mock_platform_session.return_value
 
     mock_model._deserialize.assert_has_calls(


### PR DESCRIPTION
*Issue #, if available:* Fixes #22 

*Description of changes:*

Wires up metrics to publish to cwl in platfom acc and provider acc (if configured). 

refactored `metrics.py` to handler multiple boto3 clients per publishing event and address a few gaps with the java plugin. 

Tested end to end, metrics showing up as expected in provider account.

`Resource.__call__` is becoming unwieldy, could use a refactor, but didn't want to muddy this pr with more refactors, so will address in a future pr.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
