### PR TITLE
Always use SessionProxy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,7 @@ repos:
       --cov-report=html
       --cov="rpdk.python"
       --cov="cloudformation_cli_python_lib"
+      --durations=5
       "tests/"
     language: system
     # ignore all files, run on hard-coded modules instead

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ max-complexity = 10
 max-line-length = 88
 select = C,E,F,W,B,B950
 # C812, C815, W503 clash with black, F723 false positive
-ignore = E501,C812,C815,W503,F723
+ignore = E501,C812,C815,C816,W503,F723
 
 [isort]
 line_length = 88
@@ -28,6 +28,7 @@ skip = env
 include_trailing_comma = true
 combine_as_imports = True
 force_grid_wrap = 0
+known_standard_library = dataclasses
 known_first_party = rpdk
 known_third_party = boto3,jinja2,cloudformation_cli_python_lib,pytest
 

--- a/src/cloudformation_cli_python_lib/callback.py
+++ b/src/cloudformation_cli_python_lib/callback.py
@@ -3,9 +3,7 @@ import logging
 from typing import Optional
 from uuid import uuid4
 
-# boto3 doesn't have stub files
-from boto3 import Session  # type: ignore
-
+from .boto3_proxy import SessionProxy
 from .interface import BaseResourceModel, HandlerErrorCode, OperationStatus
 from .utils import KitchenSinkEncoder
 
@@ -13,7 +11,7 @@ LOG = logging.getLogger(__name__)
 
 
 def report_progress(  # pylint: disable=too-many-arguments
-    session: Session,
+    session: SessionProxy,
     bearer_token: str,
     error_code: Optional[HandlerErrorCode],
     operation_status: OperationStatus,

--- a/src/cloudformation_cli_python_lib/resource.py
+++ b/src/cloudformation_cli_python_lib/resource.py
@@ -181,11 +181,7 @@ class Resource:
             platform_sess = _get_boto_session(event.requestData.platformCredentials)
             caller_sess = _get_boto_session(event.requestData.callerCredentials)
             provider_sess = _get_boto_session(event.requestData.providerCredentials)
-            # zero out credentials. this isn't so much to prevent targeted abuse,
-            # but to prevent accidental logging and re-use
-            event.requestData.platformCredentials = None
-            event.requestData.callerCredentials = None
-            event.requestData.providerCredentials = None
+            # credentials are used when rescheduling, so can't zero them out (for now)
             if platform_sess is None:
                 raise ValueError("No platform credentials")
             action = Action[event.action]

--- a/src/cloudformation_cli_python_lib/resource.py
+++ b/src/cloudformation_cli_python_lib/resource.py
@@ -1,12 +1,10 @@
 import json
 import logging
+import traceback
 from datetime import datetime
 from functools import wraps
 from time import sleep
 from typing import Any, Callable, MutableMapping, Optional, Tuple, Type, Union
-
-# boto3 doesn't have stub files
-import boto3  # type: ignore
 
 from .boto3_proxy import SessionProxy, _get_boto_session
 from .callback import report_progress
@@ -19,8 +17,8 @@ from .interface import (
     ProgressEvent,
 )
 from .log_delivery import ProviderLogHandler
-from .metrics import MetricPublisher, MetricsPublisherProxy
-from .scheduler import CloudWatchScheduler
+from .metrics import MetricsPublisherProxy
+from .scheduler import cleanup_cloudwatch_events, reschedule_after_minutes
 from .utils import (
     BaseResourceModel,
     Credentials,
@@ -81,7 +79,7 @@ class Resource:
         handler_request: HandlerRequest,
         handler_response: ProgressEvent,
         context: LambdaContext,
-        session: boto3.Session,
+        session: SessionProxy,
     ) -> bool:
         if handler_response.status != OperationStatus.IN_PROGRESS:
             return False
@@ -100,7 +98,8 @@ class Resource:
             sleep(callback_delay_s)
             return True
         callback_delay_min = int(callback_delay_s / 60)
-        CloudWatchScheduler(boto3_session=session).reschedule_after_minutes(
+        reschedule_after_minutes(
+            session,
             function_arn=context.invoked_function_arn,
             minutes_from_now=callback_delay_min,
             handler_request=handler_request,
@@ -142,11 +141,11 @@ class Resource:
                 **event.request
             ).to_modelled(self._model_cls)
 
-            session = _get_boto_session(creds, event.region_name)
+            session = _get_boto_session(creds, event.region)
             action = Action[event.action]
         except Exception as e:  # pylint: disable=broad-except
             LOG.exception("Invalid request")
-            raise InvalidRequest(f"{e} ({type(e).__name__})") from e
+            raise InternalFailure(f"{e} ({type(e).__name__})") from e
         return session, request, action, event.callbackContext or {}
 
     @_ensure_serialize
@@ -168,40 +167,27 @@ class Resource:
             msg = str(e)
         return ProgressEvent.failed(HandlerErrorCode.InternalFailure, msg)
 
+    @staticmethod
     def _parse_request(
-        self, event_data: MutableMapping[str, Any]
+        event_data: MutableMapping[str, Any]
     ) -> Tuple[
-        Tuple[Optional[SessionProxy], Optional[boto3.Session], boto3.Session],
-        BaseResourceHandlerRequest,
+        Tuple[Optional[SessionProxy], Optional[SessionProxy], SessionProxy],
         Action,
         MutableMapping[str, Any],
         HandlerRequest,
     ]:
         try:
             event = HandlerRequest.deserialize(event_data)
-            caller_creds = event.requestData.callerCredentials
-            provider_creds = event.requestData.providerCredentials
-            platform_creds = event.requestData.platformCredentials
-            request: BaseResourceHandlerRequest = UnmodelledRequest(
-                clientRequestToken=event.bearerToken,
-                desiredResourceState=event.requestData.resourceProperties,
-                previousResourceState=event.requestData.previousResourceProperties,
-                logicalResourceIdentifier=event.requestData.logicalResourceId,
-            ).to_modelled(self._model_cls)
-            caller_sess = _get_boto_session(caller_creds, event.region)
-            # No need to proxy as platform creds are required in the request
-            platform_sess = boto3.Session(
-                aws_access_key_id=platform_creds.accessKeyId,
-                aws_secret_access_key=platform_creds.secretAccessKey,
-                aws_session_token=platform_creds.sessionToken,
-            )
-            provider_sess = None
-            if provider_creds:
-                provider_sess = boto3.Session(
-                    aws_access_key_id=provider_creds.accessKeyId,
-                    aws_secret_access_key=provider_creds.secretAccessKey,
-                    aws_session_token=provider_creds.sessionToken,
-                )
+            platform_sess = _get_boto_session(event.requestData.platformCredentials)
+            caller_sess = _get_boto_session(event.requestData.callerCredentials)
+            provider_sess = _get_boto_session(event.requestData.providerCredentials)
+            # zero out credentials. this isn't so much to prevent targeted abuse,
+            # but to prevent accidental logging and re-use
+            event.requestData.platformCredentials = None
+            event.requestData.callerCredentials = None
+            event.requestData.providerCredentials = None
+            if platform_sess is None:
+                raise ValueError("No platform credentials")
             action = Action[event.action]
             callback_context = event.requestContext.get("callbackContext", {})
         except Exception as e:  # pylint: disable=broad-except
@@ -209,31 +195,50 @@ class Resource:
             raise InvalidRequest(f"{e} ({type(e).__name__})") from e
         return (
             (caller_sess, provider_sess, platform_sess),
-            request,
             action,
             callback_context,
             event,
         )
+
+    def _cast_resource_request(
+        self, request: HandlerRequest
+    ) -> BaseResourceHandlerRequest:
+        try:
+            return UnmodelledRequest(
+                clientRequestToken=request.bearerToken,
+                desiredResourceState=request.requestData.resourceProperties,
+                previousResourceState=request.requestData.previousResourceProperties,
+                logicalResourceIdentifier=request.requestData.logicalResourceId,
+            ).to_modelled(self._model_cls)
+        except Exception as e:  # pylint: disable=broad-except
+            LOG.exception("Invalid request")
+            raise InvalidRequest(f"{e} ({type(e).__name__})") from e
 
     # TODO: refactor to reduce branching and locals
     @_ensure_serialize  # noqa: C901
     def __call__(  # pylint: disable=too-many-locals  # noqa: C901
         self, event_data: MutableMapping[str, Any], context: LambdaContext
     ) -> MutableMapping[str, Any]:
+        logs_setup = False
+
+        def print_or_log(message: str) -> None:
+            if logs_setup:
+                LOG.exception(message, exc_info=True)
+            else:
+                print(message)
+                traceback.print_exc()
+
         try:
-            ProviderLogHandler.setup(event_data)
-            sessions, request, action, callback, event = self._parse_request(event_data)
+            sessions, action, callback, event = self._parse_request(event_data)
             caller_sess, provider_sess, platform_sess = sessions
-            metrics = MetricsPublisherProxy()
-            metrics.add_metrics_publisher(
-                MetricPublisher(event.awsAccountId, event.resourceType, platform_sess)
-            )
-            if provider_sess:
-                metrics.add_metrics_publisher(
-                    MetricPublisher(
-                        event.awsAccountId, event.resourceType, provider_sess
-                    )
-                )
+            ProviderLogHandler.setup(event, provider_sess)
+            logs_setup = True
+
+            request = self._cast_resource_request(event)
+
+            metrics = MetricsPublisherProxy(event.awsAccountId, event.resourceType)
+            metrics.add_metrics_publisher(platform_sess)
+            metrics.add_metrics_publisher(provider_sess)
             # Acknowledge the task for first time invocation
             if not event.requestContext:
                 report_progress(
@@ -248,7 +253,8 @@ class Resource:
             else:
                 # If this invocation was triggered by a 're-invoke' CloudWatch Event,
                 # clean it up
-                CloudWatchScheduler(platform_sess).cleanup_cloudwatch_events(
+                cleanup_cloudwatch_events(
+                    platform_sess,
                     event.requestContext.get("cloudWatchEventsRuleName", ""),
                     event.requestContext.get("cloudWatchEventsTargetId", ""),
                 )
@@ -285,14 +291,17 @@ class Resource:
                     event, progress, context, platform_sess
                 )
         except _HandlerError as e:
-            LOG.exception("Handler error", exc_info=True)
+            print_or_log("Handler error")
             progress = e.to_progress_event()
         except Exception as e:  # pylint: disable=broad-except
-            LOG.exception("Exception caught", exc_info=True)
+            print_or_log("Exception caught")
             progress = ProgressEvent.failed(HandlerErrorCode.InternalFailure, str(e))
         except BaseException as e:  # pylint: disable=broad-except
-            LOG.critical("Base exception caught (this is usually bad)", exc_info=True)
+            print_or_log("Base exception caught (this is usually bad)")
             progress = ProgressEvent.failed(HandlerErrorCode.InternalFailure, str(e))
+
+        # use the raw event_data as a last-ditch attempt to call back if the
+        # request is invalid
         return progress._serialize(  # pylint: disable=protected-access
             to_response=True, bearer_token=event_data.get("bearerToken")
         )

--- a/src/cloudformation_cli_python_lib/scheduler.py
+++ b/src/cloudformation_cli_python_lib/scheduler.py
@@ -3,56 +3,58 @@ import logging
 from datetime import datetime, timedelta
 from uuid import uuid4
 
-# boto3 doesn't have stub files
-from boto3 import Session  # type: ignore
-
 from botocore.exceptions import ClientError  # type: ignore
 
+from .boto3_proxy import SessionProxy
 from .utils import HandlerRequest, KitchenSinkEncoder
 
 LOG = logging.getLogger(__name__)
 
 
-class CloudWatchScheduler:
-    def __init__(self, boto3_session: Session):
-        self.client = boto3_session.client("events")
+def reschedule_after_minutes(
+    session: SessionProxy,
+    function_arn: str,
+    minutes_from_now: int,
+    handler_request: HandlerRequest,
+) -> None:
+    client = session.client("events")
+    cron = _min_to_cron(max(minutes_from_now, 1))
+    uuid = str(uuid4())
+    rule_name = f"reinvoke-handler-{uuid}"
+    target_id = f"reinvoke-target-{uuid}"
+    handler_request.requestContext["cloudWatchEventsRuleName"] = rule_name
+    handler_request.requestContext["cloudWatchEventsTargetId"] = target_id
+    json_request = json.dumps(handler_request.serialize(), cls=KitchenSinkEncoder)
+    LOG.info("Scheduling re-invoke at %s (%s)", cron, uuid)
+    client.put_rule(Name=rule_name, ScheduleExpression=cron, State="ENABLED")
+    client.put_targets(
+        Rule=rule_name,
+        Targets=[{"Id": target_id, "Arn": function_arn, "Input": json_request}],
+    )
 
-    def reschedule_after_minutes(
-        self, function_arn: str, minutes_from_now: int, handler_request: HandlerRequest
-    ) -> None:
-        cron = self._min_to_cron(max(minutes_from_now, 1))
-        uuid = str(uuid4())
-        rule_name = f"reinvoke-handler-{uuid}"
-        target_id = f"reinvoke-target-{uuid}"
-        handler_request.requestContext["cloudWatchEventsRuleName"] = rule_name
-        handler_request.requestContext["cloudWatchEventsTargetId"] = target_id
-        json_request = json.dumps(handler_request.serialize(), cls=KitchenSinkEncoder)
-        LOG.info("Scheduling re-invoke at %s (%s)", cron, uuid)
-        self.client.put_rule(Name=rule_name, ScheduleExpression=cron, State="ENABLED")
-        self.client.put_targets(
-            Rule=rule_name,
-            Targets=[{"Id": target_id, "Arn": function_arn, "Input": json_request}],
+
+def cleanup_cloudwatch_events(
+    session: SessionProxy, rule_name: str, target_id: str
+) -> None:
+    client = session.client("events")
+    try:
+        if target_id and rule_name:
+            client.remove_targets(Rule=rule_name, Ids=[target_id])
+    except ClientError as e:
+        LOG.error(
+            "Error cleaning CloudWatchEvents Target (targetId=%s): %s", target_id, e
+        )
+    try:
+        if rule_name:
+            client.delete_rule(Name=rule_name, Force=True)
+    except ClientError as e:
+        LOG.error(
+            "Error cleaning CloudWatchEvents (ruleName=%s): %s", rule_name, str(e)
         )
 
-    def cleanup_cloudwatch_events(self, rule_name: str, target_id: str) -> None:
-        try:
-            if target_id and rule_name:
-                self.client.remove_targets(Rule=rule_name, Ids=[target_id])
-        except ClientError as e:
-            LOG.error(
-                "Error cleaning CloudWatchEvents Target (targetId=%s): %s", target_id, e
-            )
-        try:
-            if rule_name:
-                self.client.delete_rule(Name=rule_name, Force=True)
-        except ClientError as e:
-            LOG.error(
-                "Error cleaning CloudWatchEvents (ruleName=%s): %s", rule_name, str(e)
-            )
 
-    @staticmethod
-    def _min_to_cron(minutes: int) -> str:
-        schedule_time = datetime.now() + timedelta(minutes=minutes)
-        # add another minute, as per java implementation
-        schedule_time = schedule_time + timedelta(minutes=1)
-        return schedule_time.strftime("cron(%M %H %d %m ? %Y)")
+def _min_to_cron(minutes: int) -> str:
+    schedule_time = datetime.now() + timedelta(minutes=minutes)
+    # add another minute, as per java implementation
+    schedule_time = schedule_time + timedelta(minutes=1)
+    return schedule_time.strftime("cron(%M %H %d %m ? %Y)")

--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -1,3 +1,4 @@
+# pylint: disable=invalid-name
 import json
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
@@ -18,17 +19,15 @@ class KitchenSinkEncoder(json.JSONEncoder):
 
 @dataclass
 class TestEvent:
-    # pylint: disable=invalid-name
     credentials: Mapping[str, str]
     action: Action
     request: Mapping[str, Any]
     callbackContext: MutableMapping[str, Any] = field(default_factory=dict)
-    region_name: Optional[str] = None
+    region: Optional[str] = None
 
 
 @dataclass
 class Credentials:
-    # pylint: disable=invalid-name
     accessKeyId: str
     secretAccessKey: str
     sessionToken: str
@@ -37,15 +36,16 @@ class Credentials:
 # pylint: disable=too-many-instance-attributes
 @dataclass
 class RequestData:
-    # pylint: disable=invalid-name
-    platformCredentials: Credentials
     providerLogGroupName: str
     logicalResourceId: str
     resourceProperties: Mapping[str, Any]
     systemTags: Mapping[str, Any]
     stackTags: Optional[Mapping[str, Any]] = None
-    callerCredentials: Optional[Credentials] = field(default=None)
-    providerCredentials: Optional[Credentials] = field(default=None)
+    # platform credentials aren't really optional, but this is used to
+    # zero them out to prevent e.g. accidental logging
+    platformCredentials: Optional[Credentials] = None
+    callerCredentials: Optional[Credentials] = None
+    providerCredentials: Optional[Credentials] = None
     previousResourceProperties: Optional[Mapping[str, Any]] = None
     previousStackTags: Optional[Mapping[str, Any]] = None
 
@@ -71,11 +71,10 @@ class RequestData:
 # pylint: disable=too-many-instance-attributes
 @dataclass
 class HandlerRequest:
-    # pylint: disable=invalid-name
+    action: str
     awsAccountId: str
     bearerToken: str
     region: str
-    action: str
     responseEndpoint: str
     resourceType: str
     resourceTypeVersion: str
@@ -100,7 +99,6 @@ class HandlerRequest:
 
 @dataclass
 class UnmodelledRequest:
-    # pylint: disable=invalid-name
     clientRequestToken: str
     desiredResourceState: Optional[Mapping[str, Any]] = None
     previousResourceState: Optional[Mapping[str, Any]] = None

--- a/tests/lib/resource_test.py
+++ b/tests/lib/resource_test.py
@@ -274,9 +274,10 @@ def test__parse_request_valid_request_and__cast_resource_request():
         any_order=True,
     )
 
-    assert request.requestData.callerCredentials is None
-    assert request.requestData.providerCredentials is None
-    assert request.requestData.platformCredentials is None
+    # credentials are used when rescheduling, so can't zero them out (for now)
+    assert request.requestData.callerCredentials is not None
+    assert request.requestData.providerCredentials is not None
+    assert request.requestData.platformCredentials is not None
 
     caller_sess, provider_sess, platform_sess = sessions
     assert caller_sess is mock_session.return_value


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* The main change is to use `SessionProxy`, instead of passing credentials around (although they are still needed for the re-invoke). I've also changed the way the request is parsed, first we try and parse the platform part. If this fails, it's now an `InternalFailure`. Then, the `ProviderLogHandler` uses this parsed data instead of re-parsing the event data itself. Finally, the request is "parsed" and if this fails, it is an `InvalidRequest` for now ("parsed" but not really, see #27 ). Both of these steps will make adding a validation library much easier.

I also reworked the MetricPublisher interface a bit like we discussed in #69 .

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
