### PR TITLE
fixed docker folder permission issue

### DIFF
--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import shutil
 import zipfile
 from pathlib import PurePosixPath
@@ -251,6 +252,7 @@ class Python36LanguagePlugin(LanguagePlugin):
                 auto_remove=True,
                 volumes=volumes,
                 stream=True,
+                user=f"{os.geteuid()}:{os.getgid()}",
             )
         except RequestsConnectionError as e:
             # it seems quite hard to reliably extract the cause from

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -244,6 +244,7 @@ def test__docker_build_good_path(plugin, tmp_path):
         auto_remove=True,
         volumes={str(tmp_path): {"bind": "/project", "mode": "rw"}},
         stream=True,
+        user=ANY,
     )
 
 
@@ -277,4 +278,5 @@ def test__docker_build_bad_path(plugin, tmp_path, exception):
         auto_remove=True,
         volumes={str(tmp_path): {"bind": "/project", "mode": "rw"}},
         stream=True,
+        user=ANY,
     )


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/cloudformation-cli-python-plugin/issues/78

*Description of changes:*
Explicitly tell Docker Run to run commands as the current user. Without this change, `pip install ... -t ./build/` will run as `root` which means `root` owns the `./build/` folder and the subsequent CLI actions fail due to a permissions mismatch.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
