### PR TITLE
Improve model deserialization

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -16,7 +16,7 @@ disable=
 
 [BASIC]
 
-good-names=e,ex,f,fp,i,j,k,n,_
+good-names=e,ex,f,fp,i,j,k,v,n,_
 
 [FORMAT]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
 dist: bionic
 sudo: false
-cache: pip
+cache:
+  pip: true
+  directories:
+    - $HOME/.cache/pre-commit
 before_install:
 - >
   pip install --upgrade pip mypy 'attrs==19.2.0'

--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -15,7 +15,7 @@ from rpdk.core.init import input_with_validation
 from rpdk.core.jsonutils.resolver import ContainerType, resolve_models
 from rpdk.core.plugin_base import LanguagePlugin
 
-from .resolver import translate_type
+from .resolver import contains_model, translate_type
 
 LOG = logging.getLogger(__name__)
 
@@ -44,6 +44,7 @@ class Python36LanguagePlugin(LanguagePlugin):
             trim_blocks=True, lstrip_blocks=True, keep_trailing_newline=True
         )
         self.env.filters["translate_type"] = translate_type
+        self.env.filters["contains_model"] = contains_model
         self.env.globals["ContainerType"] = ContainerType
         self.namespace = None
         self.package_name = None

--- a/python/rpdk/python/resolver.py
+++ b/python/rpdk/python/resolver.py
@@ -33,3 +33,11 @@ def translate_type(resolved_type):
         return f"AbstractSet[{item_type}]"
 
     raise ValueError(f"Unknown container type {resolved_type.container}")
+
+
+def contains_model(resolved_type):
+    if resolved_type.container == ContainerType.LIST:
+        return contains_model(resolved_type.type)
+    if resolved_type.container == ContainerType.MODEL:
+        return True
+    return False

--- a/python/rpdk/python/resolver.py
+++ b/python/rpdk/python/resolver.py
@@ -38,6 +38,4 @@ def translate_type(resolved_type):
 def contains_model(resolved_type):
     if resolved_type.container in [ContainerType.LIST, ContainerType.SET]:
         return contains_model(resolved_type.type)
-    if resolved_type.container == ContainerType.MODEL:
-        return True
-    return False
+    return resolved_type.container == ContainerType.MODEL

--- a/python/rpdk/python/resolver.py
+++ b/python/rpdk/python/resolver.py
@@ -36,7 +36,7 @@ def translate_type(resolved_type):
 
 
 def contains_model(resolved_type):
-    if resolved_type.container == ContainerType.LIST:
+    if resolved_type.container in [ContainerType.LIST, ContainerType.SET]:
         return contains_model(resolved_type.type)
     if resolved_type.container == ContainerType.MODEL:
         return True

--- a/python/rpdk/python/templates/models.py
+++ b/python/rpdk/python/templates/models.py
@@ -15,8 +15,8 @@ from typing import (
 )
 
 from cloudformation_cli_python_lib.interface import (
+    BaseModel,
     BaseResourceHandlerRequest,
-    BaseResourceModel,
 )
 from cloudformation_cli_python_lib.recast import recast_object
 from cloudformation_cli_python_lib.utils import deserialize_list
@@ -39,7 +39,7 @@ class ResourceHandlerRequest(BaseResourceHandlerRequest):
 
 {% for model, properties in models.items() %}
 @dataclass
-class {{ model }}(BaseResourceModel):
+class {{ model }}(BaseModel):
     {% for name, type in properties.items() %}
     {{ name }}: Optional[{{ type|translate_type }}]
     {% endfor %}

--- a/src/cloudformation_cli_python_lib/callback.py
+++ b/src/cloudformation_cli_python_lib/callback.py
@@ -4,7 +4,7 @@ from typing import Optional
 from uuid import uuid4
 
 from .boto3_proxy import SessionProxy
-from .interface import BaseResourceModel, HandlerErrorCode, OperationStatus
+from .interface import BaseModel, HandlerErrorCode, OperationStatus
 from .utils import KitchenSinkEncoder
 
 LOG = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ def report_progress(  # pylint: disable=too-many-arguments
     error_code: Optional[HandlerErrorCode],
     operation_status: OperationStatus,
     current_operation_status: Optional[OperationStatus],
-    resource_model: Optional[BaseResourceModel],
+    resource_model: Optional[BaseModel],
     status_message: str,
 ) -> None:
     client = session.client("cloudformation")

--- a/src/cloudformation_cli_python_lib/interface.py
+++ b/src/cloudformation_cli_python_lib/interface.py
@@ -68,6 +68,8 @@ class BaseResourceModel:
                 ser[k] = v._serialize()  # pylint: disable=protected-access
             elif v is None:
                 del_keys.append(k)
+            else:
+                ser[k] = v
         for k in del_keys:
             del ser[k]
         return ser

--- a/src/cloudformation_cli_python_lib/interface.py
+++ b/src/cloudformation_cli_python_lib/interface.py
@@ -57,7 +57,7 @@ class HandlerErrorCode(str, _AutoName):
     InternalFailure = auto()
 
 
-class BaseResourceModel:
+class BaseModel:
     def _serialize(self) -> Mapping[str, Any]:
         return {
             k: self._serialize_item(v)
@@ -68,7 +68,7 @@ class BaseResourceModel:
     def _serialize_item(self, v: Any) -> Any:
         if isinstance(v, list):
             return self._serialize_list(v)
-        if isinstance(v, BaseResourceModel):
+        if isinstance(v, BaseModel):
             return v._serialize()  # pylint: disable=protected-access
         return v
 
@@ -77,8 +77,8 @@ class BaseResourceModel:
 
     @classmethod
     def _deserialize(
-        cls: Type["BaseResourceModel"], json_data: Optional[Mapping[str, Any]]
-    ) -> Optional["BaseResourceModel"]:
+        cls: Type["BaseModel"], json_data: Optional[Mapping[str, Any]]
+    ) -> Optional["BaseModel"]:
         raise NotImplementedError()
 
 
@@ -91,8 +91,8 @@ class ProgressEvent:
     message: str = ""
     callbackContext: Optional[MutableMapping[str, Any]] = None
     callbackDelaySeconds: int = 0
-    resourceModel: Optional[BaseResourceModel] = None
-    resourceModels: Optional[List[BaseResourceModel]] = None
+    resourceModel: Optional[BaseModel] = None
+    resourceModels: Optional[List[BaseModel]] = None
     nextToken: Optional[str] = None
 
     def _serialize(
@@ -132,7 +132,7 @@ class ProgressEvent:
 class BaseResourceHandlerRequest:
     # pylint: disable=invalid-name
     clientRequestToken: str
-    desiredResourceState: Optional[BaseResourceModel]
-    previousResourceState: Optional[BaseResourceModel]
+    desiredResourceState: Optional[BaseModel]
+    previousResourceState: Optional[BaseModel]
     logicalResourceIdentifier: Optional[str]
     nextToken: Optional[str]

--- a/src/cloudformation_cli_python_lib/interface.py
+++ b/src/cloudformation_cli_python_lib/interface.py
@@ -59,31 +59,21 @@ class HandlerErrorCode(str, _AutoName):
 
 class BaseResourceModel:
     def _serialize(self) -> Mapping[str, Any]:
-        ser = self.__dict__
-        del_keys = []
-        for k, v in ser.items():
-            if isinstance(v, list):
-                ser[k] = self._serialize_list(v)
-            elif isinstance(v, BaseResourceModel):
-                ser[k] = v._serialize()  # pylint: disable=protected-access
-            elif v is None:
-                del_keys.append(k)
-            else:
-                ser[k] = v
-        for k in del_keys:
-            del ser[k]
-        return ser
+        return {
+            k: self._serialize_item(v)
+            for k, v in self.__dict__.items()
+            if v is not None
+        }
 
-    def _serialize_list(self, v: List[Any]) -> List[Any]:
-        ser: List[Any] = []
-        for i in v:
-            if isinstance(i, list):
-                ser.append(self._serialize_list(i))
-            elif isinstance(i, BaseResourceModel):
-                ser.append(i._serialize())  # pylint: disable=protected-access
-            else:
-                ser.append(i)
-        return ser
+    def _serialize_item(self, v: Any) -> Any:
+        if isinstance(v, list):
+            return self._serialize_list(v)
+        if isinstance(v, BaseResourceModel):
+            return v._serialize()  # pylint: disable=protected-access
+        return v
+
+    def _serialize_list(self, src_list: List[Any]) -> List[Any]:
+        return [self._serialize_item(i) for i in src_list]
 
     @classmethod
     def _deserialize(

--- a/src/cloudformation_cli_python_lib/recast.py
+++ b/src/cloudformation_cli_python_lib/recast.py
@@ -1,0 +1,87 @@
+# ignoring mypy on the import as it catches ForwardRef as invalid, and we are using it
+# for introspection https://docs.python.org/3/library/typing.html#typing.ForwardRef
+from typing import Any, Dict, ForwardRef, List, Mapping  # type: ignore
+
+from .exceptions import InvalidRequest
+
+
+# CloudFormation recasts all primitive types as strings, this tries to set them back to
+# the types in the type hints
+def recast_object(
+    cls: Any, json_data: Mapping[str, Any], classes: Dict[str, Any]
+) -> None:
+    if not isinstance(json_data, dict):
+        raise InvalidRequest(f"Can only parse dict items, not {type(json_data)}")
+    for k, v in json_data.items():
+        if isinstance(v, dict):
+            child_cls = _field_to_type(cls.__dataclass_fields__[k].type, k, classes)
+            recast_object(child_cls, v, classes)
+        elif isinstance(v, list):
+            json_data[k] = _recast_lists(cls, k, v, classes)
+        elif isinstance(v, str):
+            dest_type = _field_to_type(cls.__dataclass_fields__[k].type, k, classes)
+            json_data[k] = _recast_primitive(dest_type, k, v)
+        else:
+            raise InvalidRequest(f"Unsupported type: {type(v)} for {k}")
+
+
+def _recast_lists(cls: Any, k: str, v: List[Any], classes: Dict[str, Any]) -> List[Any]:
+    casted_list: List[Any] = []
+    if k in cls.__dataclass_fields__:
+        cls = _field_to_type(cls.__dataclass_fields__[k].type, k, classes)
+    for item in v:
+        if isinstance(item, str):
+            casted_item: Any = _recast_primitive(cls, k, item)
+        elif isinstance(item, list):
+            casted_item = _recast_lists(cls, k, item, classes)
+        elif isinstance(item, dict):
+            recast_object(cls, item, classes)
+            casted_item = item
+        else:
+            raise InvalidRequest(f"Unsupported type: {type(v)} for {k}")
+        casted_list.append(casted_item)
+    return casted_list
+
+
+def _recast_primitive(cls: Any, k: str, v: str) -> Any:
+    if cls == bool:
+        if v.lower() == "true":
+            return True
+        if v.lower() == "false":
+            return False
+        raise InvalidRequest(f'value for {k} "{v}" is not boolean')
+    return cls(v)
+
+
+def _field_to_type(field: Any, key: str, classes: Dict[str, Any]) -> Any:
+    if field in [int, float, str, bool]:
+        return field
+    # If it's a ForwardRef we need to find base type
+    if isinstance(field, ForwardRef):
+        # Assuming codegen added an _ as a prefix, removing it and then gettting the
+        # class from model classes
+        return classes[field.__forward_arg__[1:]]
+    # Assuming this is a generic object created by typing.Union
+    try:
+        possible_types = field.__args__
+    except AttributeError:
+        raise InvalidRequest(f"Cannot process type {field.__repr__()} for field {key}")
+    # Assuming that the union is generated from typing.Optional, so only
+    # contains one type and None
+    # pylint: disable=unidiomatic-typecheck
+    fields = [t for t in possible_types if type(None) != t]
+    if len(fields) != 1:
+        raise InvalidRequest(f"Cannot process type {field.__repr__()} for field {key}")
+    field = fields[0]
+    # If it's a primitive we're done
+    if field in [int, float, str, bool]:
+        return field
+    # If it's a ForwardRef we need to find base type
+    if isinstance(field, ForwardRef):
+        # Assuming codegen added an _ as a prefix, removing it and then gettting the
+        # class from model classes
+        return classes[field.__forward_arg__[1:]]
+    # If it's not a type we don't know how to handle we bail
+    if field._name not in ["Sequence"]:  # pylint: disable=protected-access
+        raise InvalidRequest(f"Cannot process type {field.__repr__()} for field {key}")
+    return _field_to_type(field.__args__[0], key, classes)

--- a/src/cloudformation_cli_python_lib/recast.py
+++ b/src/cloudformation_cli_python_lib/recast.py
@@ -90,12 +90,14 @@ def _field_to_type(field: Any, key: str, classes: Dict[str, Any]) -> Any:
     # Assuming this is a generic object created by typing.Union
     try:
         possible_types = field.__args__
+        if not possible_types:
+            raise InvalidRequest(f"Cannot process type {field} for field {key}")
     except AttributeError:
         raise InvalidRequest(f"Cannot process type {field} for field {key}")
     # Assuming that the union is generated from typing.Optional, so only
     # contains one type and None
     # pylint: disable=unidiomatic-typecheck
-    fields = [t for t in possible_types if type(None) != t] if possible_types else []
+    fields = [t for t in possible_types if type(None) != t]
     if len(fields) != 1:
         raise InvalidRequest(f"Cannot process type {field} for field {key}")
     field = fields[0]

--- a/src/cloudformation_cli_python_lib/recast.py
+++ b/src/cloudformation_cli_python_lib/recast.py
@@ -57,7 +57,7 @@ def _field_to_type(field: Any, key: str, classes: Dict[str, Any]) -> Any:
         return field
     # If it's a ForwardRef we need to find base type
     if isinstance(field, get_forward_ref_type()):
-        # Assuming codegen added an _ as a prefix, removing it and then gettting the
+        # Assuming codegen added an _ as a prefix, removing it and then getting the
         # class from model classes
         return classes[field.__forward_arg__[1:]]
     # Assuming this is a generic object created by typing.Union
@@ -77,7 +77,7 @@ def _field_to_type(field: Any, key: str, classes: Dict[str, Any]) -> Any:
         return field
     # If it's a ForwardRef we need to find base type
     if isinstance(field, get_forward_ref_type()):
-        # Assuming codegen added an _ as a prefix, removing it and then gettting the
+        # Assuming codegen added an _ as a prefix, removing it and then getting the
         # class from model classes
         return classes[field.__forward_arg__[1:]]
     # If it's not a type we don't know how to handle we bail

--- a/src/cloudformation_cli_python_lib/recast.py
+++ b/src/cloudformation_cli_python_lib/recast.py
@@ -79,7 +79,8 @@ def _recast_primitive(cls: Any, k: str, v: str) -> Any:
     return cls(v)
 
 
-def _field_to_type(field: Any, key: str, classes: Dict[str, Any]) -> Any:
+# yes, introspecting type hints is ugly, but hopefully only needed temporarily
+def _field_to_type(field: Any, key: str, classes: Dict[str, Any]) -> Any:  # noqa: C901
     if field in [int, float, str, bool, typing.Any]:
         return field
     # If it's a ForwardRef we need to find base type

--- a/src/cloudformation_cli_python_lib/recast.py
+++ b/src/cloudformation_cli_python_lib/recast.py
@@ -33,23 +33,17 @@ def _recast_lists(cls: Any, k: str, v: List[Any], classes: Dict[str, Any]) -> Li
     # Leave as is if type is Any
     if cls == typing.Any:
         return v
-    casted_list: List[Any] = []
     if "__dataclass_fields__" not in dir(cls):
         pass
     elif k in cls.__dataclass_fields__:
         cls = _field_to_type(cls.__dataclass_fields__[k].type, k, classes)
-    for item in v:
-        casted_list.append(cast_sequence_item(cls, k, item, classes))
-    return casted_list
+    return [cast_sequence_item(cls, k, item, classes) for item in v]
 
 
 def _recast_sets(cls: Any, k: str, v: Set[Any], classes: Dict[str, Any]) -> Set[Any]:
-    casted_set: Set[Any] = set()
     if "__dataclass_fields__" in dir(cls):
         cls = _field_to_type(cls.__dataclass_fields__[k].type, k, classes)
-    for item in v:
-        casted_set.add(cast_sequence_item(cls, k, item, classes))
-    return casted_set
+    return {cast_sequence_item(cls, k, item, classes) for item in v}
 
 
 def cast_sequence_item(cls: Any, k: str, item: Any, classes: Dict[str, Any]) -> Any:

--- a/src/cloudformation_cli_python_lib/resource.py
+++ b/src/cloudformation_cli_python_lib/resource.py
@@ -20,7 +20,7 @@ from .log_delivery import ProviderLogHandler
 from .metrics import MetricsPublisherProxy
 from .scheduler import cleanup_cloudwatch_events, reschedule_after_minutes
 from .utils import (
-    BaseResourceModel,
+    BaseModel,
     Credentials,
     HandlerRequest,
     KitchenSinkEncoder,
@@ -60,11 +60,9 @@ def _ensure_serialize(
 
 
 class Resource:
-    def __init__(
-        self, type_name: str, resouce_model_cls: Type[BaseResourceModel]
-    ) -> None:
+    def __init__(self, type_name: str, resouce_model_cls: Type[BaseModel]) -> None:
         self.type_name = type_name
-        self._model_cls: Type[BaseResourceModel] = resouce_model_cls
+        self._model_cls: Type[BaseModel] = resouce_model_cls
         self._handlers: MutableMapping[Action, HandlerSignature] = {}
 
     def handler(self, action: Action) -> Callable[[HandlerSignature], HandlerSignature]:

--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -15,7 +15,7 @@ from typing import (
 )
 
 from .exceptions import InvalidRequest
-from .interface import Action, BaseResourceHandlerRequest, BaseResourceModel
+from .interface import Action, BaseModel, BaseResourceHandlerRequest
 
 
 class KitchenSinkEncoder(json.JSONEncoder):
@@ -116,9 +116,7 @@ class UnmodelledRequest:
     logicalResourceIdentifier: Optional[str] = None
     nextToken: Optional[str] = None
 
-    def to_modelled(
-        self, model_cls: Type[BaseResourceModel]
-    ) -> BaseResourceHandlerRequest:
+    def to_modelled(self, model_cls: Type[BaseModel]) -> BaseResourceHandlerRequest:
         # pylint: disable=protected-access
         return BaseResourceHandlerRequest(
             clientRequestToken=self.clientRequestToken,

--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -139,13 +139,12 @@ def deserialize_list(
 ) -> Optional[List[Any]]:
     if not json_data:
         return None
-    output = []
-    for item in json_data:
-        if isinstance(item, list):
-            output.append(deserialize_list(item, inner_dataclass))
-        elif isinstance(item, dict):
-            # pylint: disable=protected-access
-            output.append(inner_dataclass._deserialize(item))
-        else:
-            raise InvalidRequest(f"cannot deserialize lists of {type(item)}")
-    return output
+    return [_deser_item(item, inner_dataclass) for item in json_data]
+
+
+def _deser_item(item: Any, inner_dataclass: Any) -> Any:
+    if isinstance(item, list):
+        return deserialize_list(item, inner_dataclass)
+    if isinstance(item, dict):
+        return inner_dataclass._deserialize(item)  # pylint: disable=protected-access
+    raise InvalidRequest(f"cannot deserialize lists of {type(item)}")

--- a/tests/lib/callback_test.py
+++ b/tests/lib/callback_test.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import boto3
 from cloudformation_cli_python_lib.callback import report_progress
 from cloudformation_cli_python_lib.interface import (
-    BaseResourceModel,
+    BaseModel,
     HandlerErrorCode,
     OperationStatus,
 )
@@ -47,7 +47,7 @@ def test_report_progress_full():
             HandlerErrorCode.InternalFailure,
             OperationStatus.FAILED,
             OperationStatus.IN_PROGRESS,
-            BaseResourceModel(),
+            BaseModel(),
             "test message",
         )
     session._cfn.record_handler_progress.assert_called_once_with(

--- a/tests/lib/interface_test.py
+++ b/tests/lib/interface_test.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import boto3
 import pytest
 from cloudformation_cli_python_lib.interface import (
-    BaseResourceModel,
+    BaseModel,
     HandlerErrorCode,
     OperationStatus,
     ProgressEvent,
@@ -35,18 +35,18 @@ def bearer_token():
 
 # don't call this TestModel, or pytest will try and execute it
 @dataclass
-class ResourceModel(BaseResourceModel):
+class ResourceModel(BaseModel):
     somekey: str
     someotherkey: str
 
 
 def test_base_resource_model__deserialize():
     with pytest.raises(NotImplementedError):
-        BaseResourceModel()._deserialize({})
+        BaseModel()._deserialize({})
 
 
 def test_base_resource_model__serialize():
-    brm = BaseResourceModel()
+    brm = BaseModel()
     assert brm._serialize() == brm.__dict__
 
 

--- a/tests/lib/recast_test.py
+++ b/tests/lib/recast_test.py
@@ -121,6 +121,28 @@ def test_field_to_type_unhandled_types():
         assert str(excinfo.value).startswith("Cannot process type ")
 
 
+def test_field_to_type_unhandled_types_36():
+    k = "key"
+
+    class SixType:
+        __args__ = None
+
+    with pytest.raises(InvalidRequest) as excinfo:
+        _field_to_type(SixType, k, {})
+    assert str(excinfo.value).startswith("Cannot process type ")
+
+
+def test_field_to_type_unhandled_types_37():
+    k = "key"
+
+    class SevenType:
+        pass
+
+    with pytest.raises(InvalidRequest) as excinfo:
+        _field_to_type(SevenType, k, {})
+    assert str(excinfo.value).startswith("Cannot process type ")
+
+
 def test_get_forward_ref_type():
     with patch("cloudformation_cli_python_lib.recast.typing") as mock_typing:
         mock_typing.ForwardRef = "3.7+"

--- a/tests/lib/recast_test.py
+++ b/tests/lib/recast_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=protected-access
 from typing import Any, Optional, Union
+from unittest.mock import patch
 
 import pytest
 from cloudformation_cli_python_lib.exceptions import InvalidRequest
@@ -7,6 +8,7 @@ from cloudformation_cli_python_lib.recast import (
     _field_to_type,
     _recast_lists,
     _recast_primitive,
+    get_forward_ref_type,
     recast_object,
 )
 
@@ -105,3 +107,13 @@ def test_field_to_type_unhandled_types():
         with pytest.raises(InvalidRequest) as excinfo:
             _field_to_type(field, k, {})
         assert str(excinfo.value).startswith("Cannot process type ")
+
+
+def test_get_forward_ref_type():
+    with patch("cloudformation_cli_python_lib.recast.typing") as mock_typing:
+        mock_typing.ForwardRef = "3.7+"
+        assert get_forward_ref_type() == "3.7+"
+    with patch("cloudformation_cli_python_lib.recast.typing") as mock_typing:
+        mock_typing._ForwardRef = "3.6"
+        get_forward_ref_type()
+        assert get_forward_ref_type() == "3.6"

--- a/tests/lib/recast_test.py
+++ b/tests/lib/recast_test.py
@@ -1,0 +1,107 @@
+# pylint: disable=protected-access
+from typing import Any, Optional, Union
+
+import pytest
+from cloudformation_cli_python_lib.exceptions import InvalidRequest
+from cloudformation_cli_python_lib.recast import (
+    _field_to_type,
+    _recast_lists,
+    _recast_primitive,
+    recast_object,
+)
+
+from .sample_model import ResourceModel as ComplexResourceModel, SimpleResourceModel
+
+
+def test_recast_object_simple():
+    payload = {
+        "AnInt": "1",
+        "ABool": "true",
+        "AList": [
+            {
+                "DeeperBool": "false",
+                "DeeperList": ["1", "2", "3"],
+                "DeeperDictInList": {"DeepestBool": "true", "DeepestList": ["3", "4"]},
+            },
+            {"DeeperDictInList": {"DeepestBool": "false", "DeepestList": ["6", "7"]}},
+        ],
+        "ADict": {
+            "DeepBool": "true",
+            "DeepList": ["10", "11"],
+            "DeepDict": {
+                "DeeperBool": "false",
+                "DeeperList": ["1", "2", "3"],
+                "DeeperDict": {"DeepestBool": "true", "DeepestList": ["13", "17"]},
+            },
+        },
+        "NestedList": [
+            [{"NestedListInt": "true", "NestedListList": ["1", "2", "3"]}],
+            [{"NestedListInt": "false", "NestedListList": ["11", "12", "13"]}],
+        ],
+    }
+    expected = {
+        "AnInt": 1,
+        "ABool": True,
+        "AList": [
+            {
+                "DeeperBool": False,
+                "DeeperList": [1, 2, 3],
+                "DeeperDictInList": {"DeepestBool": True, "DeepestList": [3, 4]},
+            },
+            {"DeeperDictInList": {"DeepestBool": False, "DeepestList": [6, 7]}},
+        ],
+        "ADict": {
+            "DeepBool": True,
+            "DeepList": [10, 11],
+            "DeepDict": {
+                "DeeperBool": False,
+                "DeeperList": [1, 2, 3],
+                "DeeperDict": {"DeepestBool": True, "DeepestList": [13, 17]},
+            },
+        },
+        "NestedList": [
+            [{"NestedListInt": True, "NestedListList": [1.0, 2.0, 3.0]}],
+            [{"NestedListInt": False, "NestedListList": [11.0, 12.0, 13.0]}],
+        ],
+    }
+    model = ComplexResourceModel._deserialize(payload)
+    assert expected == payload
+    assert expected == model._serialize()
+
+
+def test_recast_object_invalid_json_type():
+    with pytest.raises(InvalidRequest) as excinfo:
+        recast_object(SimpleResourceModel, [], {})
+    assert str(excinfo.value) == f"Can only parse dict items, not {type([])}"
+
+
+def test_recast_object_invalid_sub_type():
+    k = "key"
+    v = (1, 2)
+    with pytest.raises(InvalidRequest) as excinfo:
+        recast_object(SimpleResourceModel, {k: v}, {})
+    assert str(excinfo.value) == f"Unsupported type: {type(v)} for {k}"
+
+
+def test_recast_list_invalid_sub_type():
+    k = "key"
+    v = (1, 2)
+    with pytest.raises(InvalidRequest) as excinfo:
+        _recast_lists(SimpleResourceModel, k, v, {})
+    assert str(excinfo.value) == f"Unsupported type: {type(v)} for {k}"
+
+
+def test_recast_boolean_invalid_value():
+    k = "key"
+    v = "not-a-bool"
+    with pytest.raises(InvalidRequest) as excinfo:
+        _recast_primitive(bool, k, v)
+    assert str(excinfo.value) == f'value for {k} "{v}" is not boolean'
+
+
+def test_field_to_type_unhandled_types():
+    k = "key"
+    for field in [Union[str, list], Any, Optional[Any]]:
+        with pytest.raises(InvalidRequest) as excinfo:
+            _field_to_type(field, k, {})
+        assert str(excinfo.value).startswith("Cannot process type ")

--- a/tests/lib/resource_test.py
+++ b/tests/lib/resource_test.py
@@ -7,7 +7,7 @@ import pytest
 from cloudformation_cli_python_lib.exceptions import InternalFailure, InvalidRequest
 from cloudformation_cli_python_lib.interface import (
     Action,
-    BaseResourceModel,
+    BaseModel,
     HandlerErrorCode,
     OperationStatus,
     ProgressEvent,
@@ -106,7 +106,7 @@ def test_entrypoint_success():
 
 def test_entrypoint_handler_raises():
     @dataclass
-    class ResourceModel(BaseResourceModel):
+    class ResourceModel(BaseModel):
         a_string: str
 
         @classmethod

--- a/tests/lib/sample_model.py
+++ b/tests/lib/sample_model.py
@@ -1,0 +1,198 @@
+# This file represents a model.py built from a complex schema to test that ser/de is
+# happening as expected
+# pylint: disable=invalid-name, too-many-instance-attributes, protected-access, abstract-method
+
+import sys
+from dataclasses import dataclass
+from inspect import getmembers, isclass
+from typing import Any, Mapping, Optional, Sequence, Type, TypeVar
+
+from cloudformation_cli_python_lib.interface import (
+    BaseResourceHandlerRequest,
+    BaseResourceModel,
+)
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+T = TypeVar("T")
+
+
+@dataclass
+class ResourceHandlerRequest(BaseResourceHandlerRequest):
+    # pylint: disable=invalid-name
+    desiredResourceState: Optional["ResourceModel"]
+    previousResourceState: Optional["ResourceModel"]
+
+
+@dataclass
+class ResourceModel(BaseResourceModel):
+    AnInt: Optional[int]
+    ABool: Optional[bool]
+    NestedList: Optional[Sequence[Sequence["_NestedList"]]]
+    AList: Optional[Sequence["_AList"]]
+    ADict: Optional["_ADict"]
+    AccessToken: Optional[str]
+    Name: Optional[str]
+    Org: Optional[str]
+    Visibility: Optional[str]
+    SshUrl: Optional[str]
+    HttpsUrl: Optional[str]
+    Namespace: Optional[str]
+    Id: Optional[int]
+
+    @classmethod
+    def _deserialize(
+        cls: Type["_ResourceModel"], json_data: Optional[Mapping[str, Any]]
+    ) -> Optional["_ResourceModel"]:
+        dataclasses = {n: o for n, o in getmembers(sys.modules[__name__]) if isclass(o)}
+        recast_object(cls, json_data, dataclasses)
+        return cls(
+            AnInt=json_data.get("AnInt"),
+            ABool=json_data.get("ABool"),
+            NestedList=deserialize_list(json_data.get("NestedList"), NestedList),
+            AList=deserialize_list(json_data.get("AList"), AList),
+            ADict=ADict._deserialize(json_data.get("ADict")),
+            AccessToken=json_data.get("AccessToken"),
+            Name=json_data.get("Name"),
+            Org=json_data.get("Org"),
+            Visibility=json_data.get("Visibility"),
+            SshUrl=json_data.get("SshUrl"),
+            HttpsUrl=json_data.get("HttpsUrl"),
+            Namespace=json_data.get("Namespace"),
+            Id=json_data.get("Id"),
+        )
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_ResourceModel = ResourceModel
+
+
+@dataclass
+class NestedList(BaseResourceModel):
+    NestedListInt: Optional[bool]
+    NestedListList: Optional[Sequence[float]]
+
+    @classmethod
+    def _deserialize(
+        cls: Type["_NestedList"], json_data: Optional[Mapping[str, Any]]
+    ) -> Optional["_NestedList"]:
+        return cls(
+            NestedListInt=json_data.get("NestedListInt"),
+            NestedListList=json_data.get("NestedListList"),
+        )
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_NestedList = NestedList
+
+
+@dataclass
+class AList(BaseResourceModel):
+    DeeperBool: Optional[bool]
+    DeeperList: Optional[Sequence[int]]
+    DeeperDictInList: Optional["_DeeperDictInList"]
+
+    @classmethod
+    def _deserialize(
+        cls: Type["_AList"], json_data: Optional[Mapping[str, Any]]
+    ) -> Optional["_AList"]:
+        return cls(
+            DeeperBool=json_data.get("DeeperBool"),
+            DeeperList=json_data.get("DeeperList"),
+            DeeperDictInList=DeeperDictInList._deserialize(
+                json_data.get("DeeperDictInList")
+            ),
+        )
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_AList = AList
+
+
+@dataclass
+class DeeperDictInList(BaseResourceModel):
+    DeepestBool: Optional[bool]
+    DeepestList: Optional[Sequence[int]]
+
+    @classmethod
+    def _deserialize(
+        cls: Type["_DeeperDictInList"], json_data: Optional[Mapping[str, Any]]
+    ) -> Optional["_DeeperDictInList"]:
+        return cls(
+            DeepestBool=json_data.get("DeepestBool"),
+            DeepestList=json_data.get("DeepestList"),
+        )
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_DeeperDictInList = DeeperDictInList
+
+
+@dataclass
+class ADict(BaseResourceModel):
+    DeepBool: Optional[bool]
+    DeepList: Optional[Sequence[int]]
+    DeepDict: Optional["_DeepDict"]
+
+    @classmethod
+    def _deserialize(
+        cls: Type["_ADict"], json_data: Optional[Mapping[str, Any]]
+    ) -> Optional["_ADict"]:
+        return cls(
+            DeepBool=json_data.get("DeepBool"),
+            DeepList=json_data.get("DeepList"),
+            DeepDict=DeepDict._deserialize(json_data.get("DeepDict")),
+        )
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_ADict = ADict
+
+
+@dataclass
+class DeepDict(BaseResourceModel):
+    DeeperBool: Optional[bool]
+    DeeperList: Optional[Sequence[int]]
+    DeeperDict: Optional["_DeeperDict"]
+
+    @classmethod
+    def _deserialize(
+        cls: Type["_DeepDict"], json_data: Optional[Mapping[str, Any]]
+    ) -> Optional["_DeepDict"]:
+        return cls(
+            DeeperBool=json_data.get("DeeperBool"),
+            DeeperList=json_data.get("DeeperList"),
+            DeeperDict=DeeperDict._deserialize(json_data.get("DeeperDict")),
+        )
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_DeepDict = DeepDict
+
+
+@dataclass
+class DeeperDict(BaseResourceModel):
+    DeepestBool: Optional[bool]
+    DeepestList: Optional[Sequence[int]]
+
+    @classmethod
+    def _deserialize(
+        cls: Type["_DeeperDict"], json_data: Optional[Mapping[str, Any]]
+    ) -> Optional["_DeeperDict"]:
+        return cls(
+            DeepestBool=json_data.get("DeepestBool"),
+            DeepestList=json_data.get("DeepestList"),
+        )
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_DeeperDict = DeeperDict
+
+
+@dataclass
+class SimpleResourceModel(BaseResourceModel):
+    AnInt: Optional[int]
+    ABool: Optional[bool]
+
+
+_SimpleResourceModel = SimpleResourceModel

--- a/tests/lib/sample_model.py
+++ b/tests/lib/sample_model.py
@@ -17,8 +17,8 @@ from typing import (
 )
 
 from cloudformation_cli_python_lib.interface import (
+    BaseModel,
     BaseResourceHandlerRequest,
-    BaseResourceModel,
 )
 from cloudformation_cli_python_lib.recast import recast_object
 from cloudformation_cli_python_lib.utils import deserialize_list
@@ -34,7 +34,7 @@ class ResourceHandlerRequest(BaseResourceHandlerRequest):
 
 
 @dataclass
-class ResourceModel(BaseResourceModel):
+class ResourceModel(BaseModel):
     ListListAny: Optional[Sequence[Sequence[Any]]]
     ListSetInt: Optional[Sequence[AbstractSet[int]]]
     ListListInt: Optional[Sequence[Sequence[int]]]
@@ -89,7 +89,7 @@ _ResourceModel = ResourceModel
 
 
 @dataclass
-class NestedList(BaseResourceModel):
+class NestedList(BaseModel):
     NestedListInt: Optional[bool]
     NestedListList: Optional[Sequence[float]]
 
@@ -108,7 +108,7 @@ _NestedList = NestedList
 
 
 @dataclass
-class AList(BaseResourceModel):
+class AList(BaseModel):
     DeeperBool: Optional[bool]
     DeeperList: Optional[Sequence[int]]
     DeeperDictInList: Optional["_DeeperDictInList"]
@@ -131,7 +131,7 @@ _AList = AList
 
 
 @dataclass
-class DeeperDictInList(BaseResourceModel):
+class DeeperDictInList(BaseModel):
     DeepestBool: Optional[bool]
     DeepestList: Optional[Sequence[int]]
 
@@ -150,7 +150,7 @@ _DeeperDictInList = DeeperDictInList
 
 
 @dataclass
-class ADict(BaseResourceModel):
+class ADict(BaseModel):
     DeepBool: Optional[bool]
     DeepList: Optional[Sequence[int]]
     DeepDict: Optional["_DeepDict"]
@@ -171,7 +171,7 @@ _ADict = ADict
 
 
 @dataclass
-class DeepDict(BaseResourceModel):
+class DeepDict(BaseModel):
     DeeperBool: Optional[bool]
     DeeperList: Optional[Sequence[int]]
     DeeperDict: Optional["_DeeperDict"]
@@ -192,7 +192,7 @@ _DeepDict = DeepDict
 
 
 @dataclass
-class DeeperDict(BaseResourceModel):
+class DeeperDict(BaseModel):
     DeepestBool: Optional[bool]
     DeepestList: Optional[Sequence[int]]
 
@@ -211,7 +211,7 @@ _DeeperDict = DeeperDict
 
 
 @dataclass
-class SimpleResourceModel(BaseResourceModel):
+class SimpleResourceModel(BaseModel):
     AnInt: Optional[int]
     ABool: Optional[bool]
 

--- a/tests/lib/sample_model.py
+++ b/tests/lib/sample_model.py
@@ -5,7 +5,16 @@
 import sys
 from dataclasses import dataclass
 from inspect import getmembers, isclass
-from typing import Any, Mapping, Optional, Sequence, Type, TypeVar
+from typing import (
+    AbstractSet,
+    Any,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+)
 
 from cloudformation_cli_python_lib.interface import (
     BaseResourceHandlerRequest,
@@ -26,6 +35,12 @@ class ResourceHandlerRequest(BaseResourceHandlerRequest):
 
 @dataclass
 class ResourceModel(BaseResourceModel):
+    ListListAny: Optional[Sequence[Sequence[Any]]]
+    ListSetInt: Optional[Sequence[AbstractSet[int]]]
+    ListListInt: Optional[Sequence[Sequence[int]]]
+    ASet: Optional[AbstractSet[Any]]
+    AnotherSet: Optional[AbstractSet[str]]
+    AFreeformDict: Optional[MutableMapping[str, Any]]
     AnInt: Optional[int]
     ABool: Optional[bool]
     NestedList: Optional[Sequence[Sequence["_NestedList"]]]
@@ -47,6 +62,12 @@ class ResourceModel(BaseResourceModel):
         dataclasses = {n: o for n, o in getmembers(sys.modules[__name__]) if isclass(o)}
         recast_object(cls, json_data, dataclasses)
         return cls(
+            ListSetInt=json_data.get("ListSetInt"),
+            ListListInt=json_data.get("ListListInt"),
+            ListListAny=json_data.get("ListListAny"),
+            ASet=json_data.get("ASet"),
+            AnotherSet=json_data.get("AnotherSet"),
+            AFreeformDict=json_data.get("AFreeformDict"),
             AnInt=json_data.get("AnInt"),
             ABool=json_data.get("ABool"),
             NestedList=deserialize_list(json_data.get("NestedList"), NestedList),

--- a/tests/lib/utils_test.py
+++ b/tests/lib/utils_test.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, call, sentinel
 
 import pytest
 from cloudformation_cli_python_lib.exceptions import InvalidRequest
-from cloudformation_cli_python_lib.interface import BaseResourceModel
+from cloudformation_cli_python_lib.interface import BaseModel
 from cloudformation_cli_python_lib.utils import (
     HandlerRequest,
     KitchenSinkEncoder,
@@ -110,7 +110,7 @@ def test_handler_request_serde_roundtrip():
 
 
 def test_unmodelled_request_to_modelled():
-    model_cls = Mock(spec_set=BaseResourceModel)
+    model_cls = Mock(spec_set=BaseModel)
     model_cls._deserialize.side_effect = [sentinel.new, sentinel.old]
 
     unmodelled = UnmodelledRequest(
@@ -133,10 +133,10 @@ def test_unmodelled_request_to_modelled():
 
 
 def test_deserialize_list_empty():
-    assert deserialize_list(None, BaseResourceModel) is None
-    assert deserialize_list([], BaseResourceModel) is None
+    assert deserialize_list(None, BaseModel) is None
+    assert deserialize_list([], BaseModel) is None
 
 
 def test_deserialize_list_invalid():
     with pytest.raises(InvalidRequest):
-        deserialize_list([(1, 2)], BaseResourceModel)
+        deserialize_list([(1, 2)], BaseModel)

--- a/tests/lib/utils_test.py
+++ b/tests/lib/utils_test.py
@@ -3,11 +3,13 @@ import json
 from unittest.mock import Mock, call, sentinel
 
 import pytest
+from cloudformation_cli_python_lib.exceptions import InvalidRequest
 from cloudformation_cli_python_lib.interface import BaseResourceModel
 from cloudformation_cli_python_lib.utils import (
     HandlerRequest,
     KitchenSinkEncoder,
     UnmodelledRequest,
+    deserialize_list,
 )
 
 import hypothesis.strategies as s
@@ -128,3 +130,13 @@ def test_unmodelled_request_to_modelled():
     assert modelled.previousResourceState == sentinel.old
     assert modelled.logicalResourceIdentifier == "bar"
     assert modelled.nextToken == "baz"
+
+
+def test_deserialize_list_empty():
+    assert deserialize_list(None, BaseResourceModel) is None
+    assert deserialize_list([], BaseResourceModel) is None
+
+
+def test_deserialize_list_invalid():
+    with pytest.raises(InvalidRequest):
+        deserialize_list([(1, 2)], BaseResourceModel)

--- a/tests/plugin/resolver_test.py
+++ b/tests/plugin/resolver_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from rpdk.core.jsonutils.resolver import ContainerType, ResolvedType
-from rpdk.python.resolver import PRIMITIVE_TYPES, translate_type
+from rpdk.python.resolver import PRIMITIVE_TYPES, contains_model, translate_type
 
 RESOLVED_TYPES = [
     (ResolvedType(ContainerType.PRIMITIVE, item_type), native_type)
@@ -46,3 +46,16 @@ def test_translate_type_set(resolved_type, native_type):
 def test_translate_type_unknown(resolved_type, _native_type):
     with pytest.raises(ValueError):
         translate_type(ResolvedType("foo", resolved_type))
+
+
+@pytest.mark.parametrize("resolved_type,_native_type", RESOLVED_TYPES)
+def test_contains_model_list_containing_primitive(resolved_type, _native_type):
+    assert contains_model(ResolvedType(ContainerType.LIST, resolved_type)) is False
+
+
+def test_contains_model_list_containing_model():
+    resolved_type = ResolvedType(
+        ContainerType.LIST,
+        ResolvedType(ContainerType.LIST, ResolvedType(ContainerType.MODEL, "Foo")),
+    )
+    assert contains_model(resolved_type) is True


### PR DESCRIPTION
improves the deserialization of the raw model into type-hinted python objects.
* ser/de can now handle complex schemas containing arrays and objects
* CloudFormation service is casting all primitive types (`integer`, `number`, `boolean`) into strings. This provides a hacky, but easy-to-remove-once-fixed-upstream, convertor that introspects the type hints and re-casts them back to their intended types.

This looks pretty large on the surface, but line count is predominantly test case data in `tests/lib/recast_test.py` and `tests/lib/sample_model.py`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
