### PR TITLE
systemTags are sometimes ommitted in the request

### DIFF
--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -39,7 +39,7 @@ class RequestData:
     providerLogGroupName: str
     logicalResourceId: str
     resourceProperties: Mapping[str, Any]
-    systemTags: Mapping[str, Any]
+    systemTags: Optional[Mapping[str, Any]] = None
     stackTags: Optional[Mapping[str, Any]] = None
     # platform credentials aren't really optional, but this is used to
     # zero them out to prevent e.g. accidental logging

--- a/tests/lib/utils_test.py
+++ b/tests/lib/utils_test.py
@@ -87,7 +87,6 @@ def test_handler_request_serde_roundtrip():
             "logicalResourceId": "myBucket",
             "resourceProperties": {},
             "previousResourceProperties": None,
-            "systemTags": {"aws:cloudformation:stack-id": "SampleStack"},
             "stackTags": {"tag1": "abc"},
             "previousStackTags": {"tag1": "def"},
         },


### PR DESCRIPTION
*Issue #, if available:* Fixes #83

*Description of changes:*
On re-invocations the serialization logic strips empty keys from the json, so `{"systemTags": {}}` becomes "{}". This PR makes the systemTags key optional.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
