### PR TITLE
recasting might happen on already cast objects (re-invokes)

### DIFF
--- a/tests/lib/recast_test.py
+++ b/tests/lib/recast_test.py
@@ -79,8 +79,10 @@ def test_recast_complex_object():
         ],
     }
     model = ComplexResourceModel._deserialize(payload)
-    assert expected == payload
-    assert expected == model._serialize()
+    assert payload == expected
+    assert model._serialize() == expected
+    # re-invocations should not fail because they already type-cast payloads
+    assert ComplexResourceModel._deserialize(payload)._serialize() == expected
 
 
 def test_recast_object_invalid_json_type():


### PR DESCRIPTION
*Issue #, if available:* Fixes #90 

*Description of changes:*

`recast.py` currently expects all primitives to be strings, which is the case for initial invocations, but re-invocations from cloudwatch events are passing in already recast events. This fix should handle that.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
