### PR TITLE
add sam-tests/ to initially generated default .gitignore

### DIFF
--- a/python/rpdk/python/data/Python.gitignore
+++ b/python/rpdk/python/data/Python.gitignore
@@ -122,3 +122,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# contains credentials
+sam-tests/


### PR DESCRIPTION
Credentials committed in `sam-tests/` in several `resource-providers` already:
[gamelift](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-gamelift/pull/9#discussion_r432213015)
[cloudwatch](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-cloudwatch/pull/2/files/1afad8dd9d53ae5210c0624ee2a8ead7818993ae#diff-83d85f3c2f1785dcc53ab51e9abd2f2c)

Other language plugins as well:
[Java](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/pull/271)
[Go](https://github.com/aws-cloudformation/cloudformation-cli-go-plugin/pull/144)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
