### PR TITLE
added new properties

### DIFF
--- a/src/cloudformation_cli_python_lib/interface.py
+++ b/src/cloudformation_cli_python_lib/interface.py
@@ -136,4 +136,4 @@ class BaseResourceHandlerRequest:
     logicalResourceIdentifier: Optional[str]
     nextToken: Optional[str]
     region: Optional[str]
-    # awsPartition: Optional[str]
+    awsPartition: Optional[str]

--- a/src/cloudformation_cli_python_lib/interface.py
+++ b/src/cloudformation_cli_python_lib/interface.py
@@ -130,5 +130,10 @@ class BaseResourceHandlerRequest:
     clientRequestToken: str
     desiredResourceState: Optional[BaseModel]
     previousResourceState: Optional[BaseModel]
+    desiredResourceTags: Optional[Mapping[str, Any]]
+    systemTags: Optional[Mapping[str, Any]]
+    awsAccountId: Optional[str]
     logicalResourceIdentifier: Optional[str]
     nextToken: Optional[str]
+    region: Optional[str]
+    # awsPartition: Optional[str]

--- a/src/cloudformation_cli_python_lib/resource.py
+++ b/src/cloudformation_cli_python_lib/resource.py
@@ -163,7 +163,11 @@ class Resource:
                 clientRequestToken=request.bearerToken,
                 desiredResourceState=request.requestData.resourceProperties,
                 previousResourceState=request.requestData.previousResourceProperties,
+                desiredResourceTags=request.requestData.stackTags,
+                systemTags=request.requestData.systemTags,
+                awsAccountId=request.awsAccountId,
                 logicalResourceIdentifier=request.requestData.logicalResourceId,
+                region=request.region,
             ).to_modelled(self._model_cls)
         except Exception as e:  # pylint: disable=broad-except
             LOG.exception("Invalid request")

--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -132,8 +132,20 @@ class UnmodelledRequest:
             logicalResourceIdentifier=self.logicalResourceIdentifier,
             nextToken=self.nextToken,
             region=self.region,
-            # awsPartition
+            awsPartition=self.get_partition(self.region),
         )
+
+    @staticmethod
+    def get_partition(region: Optional[str]) -> Optional[str]:
+        if region is None:
+            return None
+
+        if region.startswith("cn"):
+            return "aws-cn"
+
+        if region.startswith("us-gov"):
+            return "aws-gov"
+        return "aws"
 
 
 class LambdaContext:

--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -113,8 +113,12 @@ class UnmodelledRequest:
     clientRequestToken: str
     desiredResourceState: Optional[Mapping[str, Any]] = None
     previousResourceState: Optional[Mapping[str, Any]] = None
+    desiredResourceTags: Optional[Mapping[str, Any]] = None
+    systemTags: Optional[Mapping[str, Any]] = None
+    awsAccountId: Optional[str] = None
     logicalResourceIdentifier: Optional[str] = None
     nextToken: Optional[str] = None
+    region: Optional[str] = None
 
     def to_modelled(self, model_cls: Type[BaseModel]) -> BaseResourceHandlerRequest:
         # pylint: disable=protected-access
@@ -122,8 +126,13 @@ class UnmodelledRequest:
             clientRequestToken=self.clientRequestToken,
             desiredResourceState=model_cls._deserialize(self.desiredResourceState),
             previousResourceState=model_cls._deserialize(self.previousResourceState),
+            desiredResourceTags=self.desiredResourceTags,
+            systemTags=self.systemTags,
+            awsAccountId=self.awsAccountId,
             logicalResourceIdentifier=self.logicalResourceIdentifier,
             nextToken=self.nextToken,
+            region=self.region,
+            # awsPartition
         )
 
 

--- a/tests/lib/utils_test.py
+++ b/tests/lib/utils_test.py
@@ -66,10 +66,6 @@ def test_handler_request_serde_roundtrip():
         "requestContext": {
             "invocation": 2,
             "callbackContext": {"contextPropertyA": "Value"},
-            "cloudWatchEventsRuleName": "reinvoke-handler-4754ac8a-623b-45fe-84bc-f5394"
-            "118a8be",
-            "cloudWatchEventsTargetId": "reinvoke-target-4754ac8a-623b-45fe-84bc-f53941"
-            "18a8be",
         },
         "requestData": {
             "callerCredentials": None,
@@ -102,7 +98,8 @@ def test_handler_request_serde_roundtrip():
     assert ser == expected
 
 
-def test_unmodelled_request_to_modelled():
+@pytest.mark.parametrize("region", ("us-east-1", "cn-region1", "us-gov-region1"))
+def test_unmodelled_request_to_modelled(region):
     model_cls = Mock(spec_set=BaseModel)
     model_cls._deserialize.side_effect = [sentinel.new, sentinel.old]
 
@@ -112,6 +109,7 @@ def test_unmodelled_request_to_modelled():
         previousResourceState={"state": "old"},
         logicalResourceIdentifier="bar",
         nextToken="baz",
+        region=region,
     )
     modelled = unmodelled.to_modelled(model_cls)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

additional properties to `BaseResourceHandlerRequest` interface:

- [x] `desiredResourceTags`: Optional[Mapping[str, Any]]
- [x] `systemTags`: Optional[Mapping[str, Any]]
- [x] `awsAccountId`: Optional[str]
- [x] `region`: Optional[str]
- [x] `awsPartition`: Optional[str]* 

*- there are no good methods in `boto.session` or `regions` to retrieve current partition. we can use [get_available_partitions](https://github.com/boto/botocore/blob/develop/botocore/regions.py#L98) to get list of partitions but that is not what is needed. We cant get endpoint interface either as [get_available_endpoints](https://github.com/boto/botocore/blob/develop/botocore/regions.py#L104) returns list of `str`. There is an outstanding PR to get partition by region https://github.com/boto/botocore/pull/1715. We could replicate something like that but might make sense to just wait.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
