### PR TITLE
Removed account ID from metric namespace

### DIFF
--- a/src/cloudformation_cli_python_lib/metrics.py
+++ b/src/cloudformation_cli_python_lib/metrics.py
@@ -49,12 +49,12 @@ class MetricPublisher:
 
 class MetricsPublisherProxy:
     @staticmethod
-    def _make_namespace(account_id: str, resource_type: str) -> str:
+    def _make_namespace(resource_type: str) -> str:
         suffix = resource_type.replace("::", "/")
-        return f"{METRIC_NAMESPACE_ROOT}/{account_id}/{suffix}"
+        return f"{METRIC_NAMESPACE_ROOT}/{suffix}"
 
-    def __init__(self, account_id: str, resource_type: str) -> None:
-        self.namespace = self._make_namespace(account_id, resource_type)
+    def __init__(self, resource_type: str) -> None:
+        self.namespace = self._make_namespace(resource_type)
         self.resource_type = resource_type
         self._publishers: List[MetricPublisher] = []
 

--- a/src/cloudformation_cli_python_lib/resource.py
+++ b/src/cloudformation_cli_python_lib/resource.py
@@ -195,7 +195,7 @@ class Resource:
 
             request = self._cast_resource_request(event)
 
-            metrics = MetricsPublisherProxy(event.awsAccountId, event.resourceType)
+            metrics = MetricsPublisherProxy(event.resourceType)
             metrics.add_metrics_publisher(provider_sess)
 
             metrics.publish_invocation_metric(datetime.utcnow(), action)

--- a/tests/lib/metrics_test.py
+++ b/tests/lib/metrics_test.py
@@ -14,10 +14,9 @@ from cloudformation_cli_python_lib.metrics import (
 
 from botocore.stub import Stubber
 
-ACCOUNT_ID = "123412341234"
 RESOURCE_TYPE = "Aa::Bb::Cc"
 NAMESPACE = MetricsPublisherProxy._make_namespace(  # pylint: disable=protected-access
-    ACCOUNT_ID, RESOURCE_TYPE
+    RESOURCE_TYPE
 )
 
 
@@ -74,13 +73,13 @@ def test_put_metric_catches_error(mock_session):
 
 def test_publish_exception_metric(mock_session):
     fake_datetime = datetime(2019, 1, 1)
-    proxy = MetricsPublisherProxy(ACCOUNT_ID, RESOURCE_TYPE)
+    proxy = MetricsPublisherProxy(RESOURCE_TYPE)
     proxy.add_metrics_publisher(mock_session)
     proxy.publish_exception_metric(fake_datetime, Action.CREATE, Exception("fake-err"))
     expected_calls = [
         call.client("cloudwatch"),
         call.client().put_metric_data(
-            Namespace="AWS/CloudFormation/123412341234/Aa/Bb/Cc",
+            Namespace="AWS/CloudFormation/Aa/Bb/Cc",
             MetricData=[
                 {
                     "MetricName": MetricTypes.HandlerException.name,
@@ -104,14 +103,14 @@ def test_publish_exception_metric(mock_session):
 
 def test_publish_invocation_metric(mock_session):
     fake_datetime = datetime(2019, 1, 1)
-    proxy = MetricsPublisherProxy(ACCOUNT_ID, RESOURCE_TYPE)
+    proxy = MetricsPublisherProxy(RESOURCE_TYPE)
     proxy.add_metrics_publisher(mock_session)
     proxy.publish_invocation_metric(fake_datetime, Action.CREATE)
 
     expected_calls = [
         call.client("cloudwatch"),
         call.client().put_metric_data(
-            Namespace="AWS/CloudFormation/123412341234/Aa/Bb/Cc",
+            Namespace="AWS/CloudFormation/Aa/Bb/Cc",
             MetricData=[
                 {
                     "MetricName": MetricTypes.HandlerInvocationCount.name,
@@ -131,14 +130,14 @@ def test_publish_invocation_metric(mock_session):
 
 def test_publish_duration_metric(mock_session):
     fake_datetime = datetime(2019, 1, 1)
-    proxy = MetricsPublisherProxy(ACCOUNT_ID, RESOURCE_TYPE)
+    proxy = MetricsPublisherProxy(RESOURCE_TYPE)
     proxy.add_metrics_publisher(mock_session)
     proxy.publish_duration_metric(fake_datetime, Action.CREATE, 100)
 
     expected_calls = [
         call.client("cloudwatch"),
         call.client().put_metric_data(
-            Namespace="AWS/CloudFormation/123412341234/Aa/Bb/Cc",
+            Namespace="AWS/CloudFormation/Aa/Bb/Cc",
             MetricData=[
                 {
                     "MetricName": MetricTypes.HandlerInvocationDuration.name,
@@ -158,14 +157,14 @@ def test_publish_duration_metric(mock_session):
 
 def test_publish_log_delivery_exception_metric(mock_session):
     fake_datetime = datetime(2019, 1, 1)
-    proxy = MetricsPublisherProxy(ACCOUNT_ID, RESOURCE_TYPE)
+    proxy = MetricsPublisherProxy(RESOURCE_TYPE)
     proxy.add_metrics_publisher(mock_session)
     proxy.publish_log_delivery_exception_metric(fake_datetime, TypeError("test"))
 
     expected_calls = [
         call.client("cloudwatch"),
         call.client().put_metric_data(
-            Namespace="AWS/CloudFormation/123412341234/Aa/Bb/Cc",
+            Namespace="AWS/CloudFormation/Aa/Bb/Cc",
             MetricData=[
                 {
                     "MetricName": MetricTypes.HandlerException.name,
@@ -191,6 +190,6 @@ def test_publish_log_delivery_exception_metric(mock_session):
 
 
 def test_metrics_publisher_proxy_add_metrics_publisher_none_safe():
-    proxy = MetricsPublisherProxy(ACCOUNT_ID, RESOURCE_TYPE)
+    proxy = MetricsPublisherProxy(RESOURCE_TYPE)
     proxy.add_metrics_publisher(None)
     assert proxy._publishers == []  # pylint: disable=protected-access


### PR DESCRIPTION
Main PR for Java plugin: https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/pull/293

The removed account ID is the customer account ID instead of the provider account ID. This means that for public types, a new metric namespace would be created each time we need to emit metrics. The main issue with this is that the internal and logging failure alarms will not work properly and service teams may not be notified of issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
