### PR TITLE
add rpdk.log to initially generated default .gitignore

### DIFF
--- a/python/rpdk/python/data/Python.gitignore
+++ b/python/rpdk/python/data/Python.gitignore
@@ -125,3 +125,5 @@ dmypy.json
 
 # contains credentials
 sam-tests/
+
+rpdk.log

--- a/python/rpdk/python/data/Python.gitignore
+++ b/python/rpdk/python/data/Python.gitignore
@@ -126,4 +126,4 @@ dmypy.json
 # contains credentials
 sam-tests/
 
-rpdk.log
+rpdk.log*


### PR DESCRIPTION
[Java](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/682214d782e20ee197ae2711bde06602d12a5d20/python/rpdk/java/data/java.gitignore#L20) and [Go](https://github.com/aws-cloudformation/cloudformation-cli-go-plugin/blob/7b9fc8d8848ad2666298fbcf077c0f2d4d264a2b/python/rpdk/go/data/go.gitignore#L6) plugins already have this in `.gitignore`

`sam-tests/` `.gitignore` PRs:
[Java](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/pull/271)
[Python](https://github.com/aws-cloudformation/cloudformation-cli-python-plugin/pull/97)
[Go](https://github.com/aws-cloudformation/cloudformation-cli-go-plugin/pull/144)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
