### PR TITLE
Make certain request fields optional to unblock contract testing.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     include_package_data=True,
     zip_safe=True,
     python_requires=">=3.6",
-    install_requires=["cloudformation-cli>=0.1,<0.2", "docker>=3.7,<5"],
+    install_requires=["cloudformation-cli>=0.1.10,<0.2", "docker>=3.7,<5"],
     entry_points={
         "rpdk.v1.languages": [
             "python37 = rpdk.python.codegen:Python37LanguagePlugin",

--- a/src/cloudformation_cli_python_lib/log_delivery.py
+++ b/src/cloudformation_cli_python_lib/log_delivery.py
@@ -43,7 +43,7 @@ class ProviderLogHandler(logging.Handler):
             stream_name = f"{request.awsAccountId}-{request.region}"
 
         log_handler = cls._get_existing_logger()
-        if provider_sess and log_group:
+        if provider_sess and log_group and request.resourceType:
             if log_handler:
                 # This is a re-used lambda container, log handler is already setup, so
                 # we just refresh the client with new creds

--- a/src/cloudformation_cli_python_lib/metrics.py
+++ b/src/cloudformation_cli_python_lib/metrics.py
@@ -16,7 +16,7 @@ def format_dimensions(dimensions: Mapping[str, str]) -> List[Mapping[str, str]]:
     return [{"Name": key, "Value": value} for key, value in dimensions.items()]
 
 
-class MetricPublisher:
+class MetricsPublisher:
     def __init__(self, session: SessionProxy, resource_type: str) -> None:
         self.client = session.client("cloudwatch")
         self.resource_type = resource_type
@@ -118,13 +118,13 @@ class MetricPublisher:
 
 class MetricsPublisherProxy:
     def __init__(self) -> None:
-        self._publishers: List[MetricPublisher] = []
+        self._publishers: List[MetricsPublisher] = []
 
     def add_metrics_publisher(
         self, session: Optional[SessionProxy], type_name: Optional[str]
     ) -> None:
         if session and type_name:
-            publisher = MetricPublisher(session, type_name)
+            publisher = MetricsPublisher(session, type_name)
             self._publishers.append(publisher)
 
     def publish_exception_metric(

--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -85,6 +85,7 @@ class HandlerRequest:
     awsAccountId: str
     bearerToken: str
     region: str
+    responseEndpoint: str
     requestData: RequestData
     stackId: Optional[str] = None
     resourceType: Optional[str] = None

--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -47,9 +47,9 @@ class Credentials:
 # pylint: disable=too-many-instance-attributes
 @dataclass
 class RequestData:
-    providerLogGroupName: str
-    logicalResourceId: str
     resourceProperties: Mapping[str, Any]
+    providerLogGroupName: Optional[str] = None
+    logicalResourceId: Optional[str] = None
     systemTags: Optional[Mapping[str, Any]] = None
     stackTags: Optional[Mapping[str, Any]] = None
     # platform credentials aren't really optional, but this is used to
@@ -85,14 +85,12 @@ class HandlerRequest:
     awsAccountId: str
     bearerToken: str
     region: str
-    responseEndpoint: str
-    resourceType: str
-    resourceTypeVersion: str
     requestData: RequestData
-    stackId: str
+    stackId: Optional[str] = None
+    resourceType: Optional[str] = None
+    resourceTypeVersion: Optional[str] = None
     callbackContext: Optional[MutableMapping[str, Any]] = None
     nextToken: Optional[str] = None
-    requestContext: MutableMapping[str, Any] = field(default_factory=dict)
 
     @classmethod
     def deserialize(cls, json_data: MutableMapping[str, Any]) -> "HandlerRequest":

--- a/tests/lib/log_delivery_test.py
+++ b/tests/lib/log_delivery_test.py
@@ -29,6 +29,7 @@ def make_payload() -> HandlerRequest:
         awsAccountId="123412341234",
         bearerToken=str(uuid4()),
         region="us-east-1",
+        responseEndpoint="",
         resourceType="Foo::Bar::Baz",
         resourceTypeVersion="4",
         requestData=RequestData(

--- a/tests/lib/log_delivery_test.py
+++ b/tests/lib/log_delivery_test.py
@@ -29,7 +29,6 @@ def make_payload() -> HandlerRequest:
         awsAccountId="123412341234",
         bearerToken=str(uuid4()),
         region="us-east-1",
-        responseEndpoint="",
         resourceType="Foo::Bar::Baz",
         resourceTypeVersion="4",
         requestData=RequestData(

--- a/tests/lib/metrics_test.py
+++ b/tests/lib/metrics_test.py
@@ -15,7 +15,7 @@ from cloudformation_cli_python_lib.metrics import (
 from botocore.stub import Stubber  # pylint: disable=C0411
 
 RESOURCE_TYPE = "Aa::Bb::Cc"
-NAMESPACE = MetricsPublisherProxy._make_namespace(  # pylint: disable=protected-access
+NAMESPACE = MetricPublisher._make_namespace(  # pylint: disable=protected-access
     RESOURCE_TYPE
 )
 
@@ -73,8 +73,8 @@ def test_put_metric_catches_error(mock_session):
 
 def test_publish_exception_metric(mock_session):
     fake_datetime = datetime(2019, 1, 1)
-    proxy = MetricsPublisherProxy(RESOURCE_TYPE)
-    proxy.add_metrics_publisher(mock_session)
+    proxy = MetricsPublisherProxy()
+    proxy.add_metrics_publisher(mock_session, RESOURCE_TYPE)
     proxy.publish_exception_metric(fake_datetime, Action.CREATE, Exception("fake-err"))
     expected_calls = [
         call.client("cloudwatch"),
@@ -103,8 +103,8 @@ def test_publish_exception_metric(mock_session):
 
 def test_publish_invocation_metric(mock_session):
     fake_datetime = datetime(2019, 1, 1)
-    proxy = MetricsPublisherProxy(RESOURCE_TYPE)
-    proxy.add_metrics_publisher(mock_session)
+    proxy = MetricsPublisherProxy()
+    proxy.add_metrics_publisher(mock_session, RESOURCE_TYPE)
     proxy.publish_invocation_metric(fake_datetime, Action.CREATE)
 
     expected_calls = [
@@ -130,8 +130,8 @@ def test_publish_invocation_metric(mock_session):
 
 def test_publish_duration_metric(mock_session):
     fake_datetime = datetime(2019, 1, 1)
-    proxy = MetricsPublisherProxy(RESOURCE_TYPE)
-    proxy.add_metrics_publisher(mock_session)
+    proxy = MetricsPublisherProxy()
+    proxy.add_metrics_publisher(mock_session, RESOURCE_TYPE)
     proxy.publish_duration_metric(fake_datetime, Action.CREATE, 100)
 
     expected_calls = [
@@ -157,8 +157,8 @@ def test_publish_duration_metric(mock_session):
 
 def test_publish_log_delivery_exception_metric(mock_session):
     fake_datetime = datetime(2019, 1, 1)
-    proxy = MetricsPublisherProxy(RESOURCE_TYPE)
-    proxy.add_metrics_publisher(mock_session)
+    proxy = MetricsPublisherProxy()
+    proxy.add_metrics_publisher(mock_session, RESOURCE_TYPE)
     proxy.publish_log_delivery_exception_metric(fake_datetime, TypeError("test"))
 
     expected_calls = [
@@ -190,6 +190,6 @@ def test_publish_log_delivery_exception_metric(mock_session):
 
 
 def test_metrics_publisher_proxy_add_metrics_publisher_none_safe():
-    proxy = MetricsPublisherProxy(RESOURCE_TYPE)
-    proxy.add_metrics_publisher(None)
+    proxy = MetricsPublisherProxy()
+    proxy.add_metrics_publisher(None, None)
     assert proxy._publishers == []  # pylint: disable=protected-access

--- a/tests/lib/metrics_test.py
+++ b/tests/lib/metrics_test.py
@@ -7,7 +7,7 @@ import boto3
 import pytest
 from cloudformation_cli_python_lib.interface import Action, MetricTypes, StandardUnit
 from cloudformation_cli_python_lib.metrics import (
-    MetricPublisher,
+    MetricsPublisher,
     MetricsPublisherProxy,
     format_dimensions,
 )
@@ -15,7 +15,7 @@ from cloudformation_cli_python_lib.metrics import (
 from botocore.stub import Stubber  # pylint: disable=C0411
 
 RESOURCE_TYPE = "Aa::Bb::Cc"
-NAMESPACE = MetricPublisher._make_namespace(  # pylint: disable=protected-access
+NAMESPACE = MetricsPublisher._make_namespace(  # pylint: disable=protected-access
     RESOURCE_TYPE
 )
 
@@ -43,7 +43,7 @@ def test_put_metric_catches_error(mock_session):
 
     mock_session.client.return_value = client
 
-    publisher = MetricPublisher(mock_session, NAMESPACE)
+    publisher = MetricsPublisher(mock_session, NAMESPACE)
     dimensions = {
         "DimensionKeyActionType": Action.CREATE.name,
         "DimensionKeyResourceType": RESOURCE_TYPE,

--- a/tests/lib/resource_test.py
+++ b/tests/lib/resource_test.py
@@ -20,10 +20,9 @@ ENTRYPOINT_PAYLOAD = {
     "bearerToken": "123456",
     "region": "us-east-1",
     "action": "CREATE",
-    "responseEndpoint": None,
     "resourceType": "AWS::Test::TestModel",
     "resourceTypeVersion": "1.0",
-    "requestContext": {},
+    "callbackContext": {},
     "requestData": {
         "callerCredentials": {
             "accessKeyId": "IASAYK835GAIFHAHEI23",
@@ -145,7 +144,7 @@ def test_entrypoint_non_mutating_action():
 
 def test_entrypoint_with_context():
     payload = ENTRYPOINT_PAYLOAD.copy()
-    payload["requestContext"] = {"a": "b"}
+    payload["callbackContext"] = {"a": "b"}
     resource = Resource(TYPE_NAME, Mock())
     event = ProgressEvent(
         status=OperationStatus.SUCCESS, message="", callbackContext={"c": "d"}

--- a/tests/lib/resource_test.py
+++ b/tests/lib/resource_test.py
@@ -20,6 +20,7 @@ ENTRYPOINT_PAYLOAD = {
     "bearerToken": "123456",
     "region": "us-east-1",
     "action": "CREATE",
+    "responseEndpoint": None,
     "resourceType": "AWS::Test::TestModel",
     "resourceTypeVersion": "1.0",
     "callbackContext": {},

--- a/tests/lib/utils_test.py
+++ b/tests/lib/utils_test.py
@@ -59,14 +59,10 @@ def test_handler_request_serde_roundtrip():
         "bearerToken": "123456",
         "region": "us-east-1",
         "action": "CREATE",
-        "responseEndpoint": "https://cloudformation.us-west-2.amazonaws.com",
         "resourceType": "AWS::Test::TestModel",
         "resourceTypeVersion": "1.0",
         "nextToken": None,
-        "requestContext": {
-            "invocation": 2,
-            "callbackContext": {"contextPropertyA": "Value"},
-        },
+        "callbackContext": {"contextPropertyA": "Value"},
         "requestData": {
             "callerCredentials": None,
             "providerCredentials": {

--- a/tests/lib/utils_test.py
+++ b/tests/lib/utils_test.py
@@ -59,6 +59,7 @@ def test_handler_request_serde_roundtrip():
         "bearerToken": "123456",
         "region": "us-east-1",
         "action": "CREATE",
+        "responseEndpoint": "https://cloudformation.us-west-2.amazonaws.com",
         "resourceType": "AWS::Test::TestModel",
         "resourceTypeVersion": "1.0",
         "nextToken": None,


### PR DESCRIPTION
*Issue #, if available:* #112 #109 

*Description of changes:* This change makes some request fields optional/removes certain fields so that contract testing via `cfn test` can complete successfully without library errors. Below are a list of the changes to the request:

* Made `resourceType`, `resourceTypeVersion`, and `stackId` optional. Making `resourceType` optional led to some issues with metrics publishing, so I had to refactor the MetricPublisher and MetricsPublisherProxy. This led to the layout being much more in line with the java plugin, where the proxy [has no required arugments for construction and simply loops through available publishers when publishing](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/src/main/java/software/amazon/cloudformation/proxy/MetricsPublisherProxy.java#L23-L36). Any arguments pertinent to metric publishing are now passed into the actual publisher class, like resource type name and provider session. The changes to metrics publishing also conditionally create the publisher and logging when there are provider logging credentials and a log group name.

* `requestContext` is removed as this is a relic of the original protocol and no longer relevant.




The first commit contains the bulk of these changes. The second commit just changes MetricPublisher->MetricsPublisher so the spelling is in line with the java plugin and the proxy :) 


Testing done:

Created a dummy resource with the latest cloudformation-cli and ran cfn-test on a resource with this new support lib. Tests did not fail in the handler support lib like previously.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
