### PR TITLE
Make responseEndpoint optional

### DIFF
--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -85,8 +85,8 @@ class HandlerRequest:
     awsAccountId: str
     bearerToken: str
     region: str
-    responseEndpoint: str
     requestData: RequestData
+    responseEndpoint: Optional[str] = None
     stackId: Optional[str] = None
     resourceType: Optional[str] = None
     resourceTypeVersion: Optional[str] = None

--- a/src/setup.py
+++ b/src/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="cloudformation-cli-python-lib",
-    version="2.1.1",
+    version="2.1.2",
     description=__doc__,
     author="Amazon Web Services",
     author_email="aws-cloudformation-developers@amazon.com",


### PR DESCRIPTION
*Issue #, if available:* #122 

*Description of changes:* While working on #120, went from completely removing responseEndpoint on the first iteration to adding it back in the next time around. Ideally, this should be marked as optional, as it is still sent from CloudFormation's backend. This should work with both `cfn test` and stack provisioning. Will fully test out in the morning before releasing.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
