### PR TITLE
Fix recast_object for dict values of primitive type

### DIFF
--- a/src/cloudformation_cli_python_lib/recast.py
+++ b/src/cloudformation_cli_python_lib/recast.py
@@ -25,7 +25,9 @@ def recast_object(
         elif isinstance(v, set):
             json_data[k] = _recast_sets(cls, k, v, classes)
         elif isinstance(v, PRIMITIVES):
-            dest_type = _field_to_type(cls.__dataclass_fields__[k].type, k, classes)
+            dest_type = cls
+            if "__dataclass_fields__" in dir(cls):
+                dest_type = _field_to_type(cls.__dataclass_fields__[k].type, k, classes)
             json_data[k] = _recast_primitive(dest_type, k, v)
         else:
             raise InvalidRequest(f"Unsupported type: {type(v)} for {k}")

--- a/tests/lib/recast_test.py
+++ b/tests/lib/recast_test.py
@@ -23,6 +23,7 @@ def test_recast_complex_object():
         "ASet": {"1", "2", "3"},
         "AnotherSet": {"a", "b", "c"},
         "AFreeformDict": {"somekey": "somevalue", "someotherkey": "1"},
+        "APrimitiveTypeDict": {"somekey": "true", "someotherkey": "false"},
         "AnInt": "1",
         "ABool": "true",
         "AList": [
@@ -54,6 +55,7 @@ def test_recast_complex_object():
         "ASet": {"1", "2", "3"},
         "AnotherSet": {"a", "b", "c"},
         "AFreeformDict": {"somekey": "somevalue", "someotherkey": "1"},
+        "APrimitiveTypeDict": {"somekey": True, "someotherkey": False},
         "AnInt": 1,
         "ABool": True,
         "AList": [

--- a/tests/lib/sample_model.py
+++ b/tests/lib/sample_model.py
@@ -41,6 +41,7 @@ class ResourceModel(BaseModel):
     ASet: Optional[AbstractSet[Any]]
     AnotherSet: Optional[AbstractSet[str]]
     AFreeformDict: Optional[MutableMapping[str, Any]]
+    APrimitiveTypeDict: Optional[MutableMapping[str, bool]]
     AnInt: Optional[int]
     ABool: Optional[bool]
     NestedList: Optional[Sequence[Sequence["_NestedList"]]]
@@ -68,6 +69,7 @@ class ResourceModel(BaseModel):
             ASet=json_data.get("ASet"),
             AnotherSet=json_data.get("AnotherSet"),
             AFreeformDict=json_data.get("AFreeformDict"),
+            APrimitiveTypeDict=json_data.get("APrimitiveTypeDict"),
             AnInt=json_data.get("AnInt"),
             ABool=json_data.get("ABool"),
             NestedList=deserialize_list(json_data.get("NestedList"), NestedList),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Handle the case when the values of a dict type are predetermined in the schema, and are a primitive type.
For instance a property definition like this:
```json
        "APrimitiveTypeDict": {
            "type": "object",
            "patternProperties": {
                ".*": {
                    "type": "boolean"
                }
            }
        }
```

This generates an attribute like I added in the test: `Optional[MutableMapping[str, bool]]`

Without this fix, the following exception gets raised: 
```
Traceback (most recent call last):
  File "/var/task/cloudformation_cli_python_lib/resource.py", line 104, in _parse_test_request
    ).to_modelled(self._model_cls)
  File "/var/task/cloudformation_cli_python_lib/utils.py", line 127, in to_modelled
    desiredResourceState=model_cls._deserialize(self.desiredResourceState),
  File "/var/task/datadog_integrations_aws/models.py", line 64, in _deserialize
    recast_object(cls, json_data, dataclasses)
  File "/var/task/cloudformation_cli_python_lib/recast.py", line 22, in recast_object
    recast_object(child_cls, v, classes)
  File "/var/task/cloudformation_cli_python_lib/recast.py", line 28, in recast_object
    if "__dataclass_fields__" in dir(cls):
AttributeError: type object 'bool' has no attribute '__dataclass_fields__'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
