### PR TITLE
Call read handler on create/update and return empty model on delete

### DIFF
--- a/python/rpdk/python/templates/handlers.py
+++ b/python/rpdk/python/templates/handlers.py
@@ -59,7 +59,8 @@ def create_handler(
         raise exceptions.InternalFailure(f"was not expecting type {e}")
         # this can also be done by returning a failed progress event
         # return ProgressEvent.failed(HandlerErrorCode.InternalFailure, f"was not expecting type {e}")
-    return progress
+
+    return read_handler(session, request, callback_context)
 
 
 @resource.handler(Action.UPDATE)
@@ -74,7 +75,7 @@ def update_handler(
         resourceModel=model,
     )
     # TODO: put code here
-    return progress
+    return read_handler(session, request, callback_context)
 
 
 @resource.handler(Action.DELETE)
@@ -86,7 +87,7 @@ def delete_handler(
     model = request.desiredResourceState
     progress: ProgressEvent = ProgressEvent(
         status=OperationStatus.IN_PROGRESS,
-        resourceModel=model,
+        resourceModel=None,
     )
     # TODO: put code here
     return progress


### PR DESCRIPTION
*Description of changes:*
Updates the handlers.py template file to be more in line with the contract definitions - https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract.html

* This PR adds the call to `read_handler` at the end of create and update, instead of returning a success progress event. 
My understanding is that this is required for stabilization and also ensures the model contains any readOnly attributes
* It also sets the model to None when returning a progress event in the delete handler. 
> When the delete handler returns SUCCESS, the ProgressEvent object MUST NOT contain a model.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
