### PR TITLE
Add travis release for both plugin and support lib.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,15 @@ jobs:
       - printf "AWS::Foo::Bar\n2\ny" | cfn init -vv
       - ls -la
       - mypy src/aws_foo_bar/ --strict --implicit-reexport
+  - stage: deploy
+    python: "3.7"
+    script:
+      - cd $(bash before_deploy.sh)
+    deploy:
+      provider: pypi
+      user: aws-cloudformation-developers
+      password:
+        secure: "KDSSnOhDMO3sHi4eeOSrsRcs3be5C1cYBdtnmTMOUz6npf39wsssBM6iJfkSdRdpWCr8k1cKodVhE3fcz+Z0vq33oPSWOvakynMrcRQk5Xe7Fzc53kesDEc562smPMiERtFfse0oO+InzIPjsfbsBzLqKlWWQGMqUxrshPmfexsOwKDo+JzT4lVflz6AGQPI0smXa9gHkAu11ne7mIlrmR7f8+mWgqzLTExIJFqYjNECOrT/gDo3zzySO13h5CXf7AM1i0o5p02b9hZ41blkS2OgBeDMSS9qN6QFPT+Erl6Q6y579/vM+knXlPzWBdbqJ2uWaeBfcZZlP7jNp6TkW1WPu4jPL/VnJ/3Eihy4rMkRBuer5zPHj0KBJZoU4jjZx5ctnsYPSZrH7Xo3CHnk1QNckXb+4GZVgz6EWAMGgRmDzJUWTzzu7Dw5EwFQZwESTETqqd+53Ht9yDeJgzA6OneZ4MsWq0OzjUFiiAKMS8BO/uiQrTv3/pJo75JJCLW8wrwTaBTZt6gTuYl+UNeuogITVCdStiH1ECZZ001Bv7tKDhcD4rVB/lJ/I8qIx9QXdWDiRhqqt1+WUl6tlA6sX2vFrTD2wqw9XNwNpIbHF8IoBRI9Cp5wO4m0CreAD6TYbPwEXKMyU5mCEQAv1zSJVag3hf/lhmAR3T7eLUPId2c="
+      distributions: sdist bdist_wheel
+      on:
+        tags: true

--- a/before_deploy.sh
+++ b/before_deploy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ "$TRAVIS_TAG" =~ plugin ]]; then
+    echo .
+elif [[ "$TRAVIS_TAG" =~ lib ]]; then
+    echo src
+fi

--- a/python/rpdk/python/__init__.py
+++ b/python/rpdk/python/__init__.py
@@ -1,5 +1,5 @@
 import logging
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/python/rpdk/python/templates/requirements.txt
+++ b/python/rpdk/python/templates/requirements.txt
@@ -1,1 +1,1 @@
-{{ support_lib_name }}==2.1.1
+{{ support_lib_name }}>=2.1.3

--- a/src/setup.py
+++ b/src/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="cloudformation-cli-python-lib",
-    version="2.1.2",
+    version="2.1.3",
     description=__doc__,
     author="Amazon Web Services",
     author_email="aws-cloudformation-developers@amazon.com",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change add a travis deployment job for both the plugin and support library. Basically, depending on the tag naming, we will release the plugin or lib. If a tag contains "plugin", the before_deploy script will not change the directory, and travis will release what is in the root directory. If a tag contains "lib", the directory changes to "src" and the support library is released. (Thanks to @lukewrites for detailing this solution for multiple pypi packages in one repo in their repo here: https://github.com/lukewrites/silly-package)

Tested on my local fork with the test pypi repository.

This also contains a version bump for both plugin and lib packages so that once merged, we can tag this commit and release it.

Example jobs: 
* [lib travis job](https://travis-ci.com/github/jotompki/cloudformation-cli-python-plugin/jobs/428376075) [released version](https://test.pypi.org/project/cloudformation-cli-python-lib/2.1.4/) (had to bump to 2.1.4  on my test because of other tries)
* [plugin](https://travis-ci.com/github/jotompki/cloudformation-cli-python-plugin/jobs/428376201) [released version](https://test.pypi.org/project/cloudformation-cli-python-plugin/2.1.3/) (same here)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
