### PR TITLE
non-strict deserializer for request data

### DIFF
--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -60,6 +60,12 @@ class RequestData:
     previousStackTags: Optional[Mapping[str, Any]] = None
     previousSystemTags: Optional[Mapping[str, Any]] = None
 
+    def __init__(self, **kwargs: Any) -> None:
+        dataclass_fields = {f.name for f in fields(self)}
+        for k, v in kwargs.items():
+            if k in dataclass_fields:
+                setattr(self, k, v)
+
     @classmethod
     def deserialize(cls, json_data: MutableMapping[str, Any]) -> "RequestData":
         req_data = RequestData(**json_data)

--- a/tests/lib/utils_test.py
+++ b/tests/lib/utils_test.py
@@ -78,18 +78,24 @@ def test_handler_request_serde_roundtrip():
             "previousResourceProperties": None,
             "stackTags": {"tag1": "abc"},
             "previousStackTags": {"tag1": "def"},
+            "undesiredField": "value",
         },
         "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e72"
         "2ae60-fe62-11e8-9a0e-0ae8cc519968",
     }
+    undesired = "undesiredField"
     ser = HandlerRequest.deserialize(payload).serialize()
     # remove None values from payload
     expected = {
-        k: {k: v for k, v in payload["requestData"].items() if v is not None}
+        k: {
+            k: v
+            for k, v in payload["requestData"].items()
+            if v is not None and k not in undesired
+        }
         if k == "requestData"
         else v
         for k, v in payload.items()
-        if v is not None
+        if v is not None and k not in undesired
     }
 
     assert ser == expected


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

prevents deserialization exceptions on any undesired properties

```terminal
% pre-commit run --all-files
isort....................................................................Passed
black....................................................................Passed
Check for case conflicts.................................................Passed
Fix End of Files.........................................................Passed
Mixed line ending........................................................Passed
Trim Trailing Whitespace.................................................Passed
Flake8...................................................................Passed
Pretty format JSON...................................(no files to check)Skipped
Check for merge conflicts................................................Passed
Check Yaml...............................................................Passed
Check blanket noqa.......................................................Passed
check for not-real mock methods..........................................Passed
use logger.warning(......................................................Passed
bandit...................................................................Passed
mypy.....................................................................Passed
pylint-local.............................................................Passed
pytest-local.............................................................Passed
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
