### PR TITLE
removing explicit docker pinning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "cloudformation-cli>=0.1.14",
-        "docker>=3.7,<5",
     ],
     entry_points={
         "rpdk.v1.languages": [


### PR DESCRIPTION
`docker` is already an indirect dependency from `cloudformation-cli`, so this was just pinning `docker` version stricter than `cloudformation-cli`, which causes issues
https://github.com/aws-cloudformation/cloudformation-cli/issues/727