### PR TITLE
cloudformation-cli-python-lib version 2.1.6

### DIFF
--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -158,7 +158,7 @@ class Python36LanguagePlugin(LanguagePlugin):
         LOG.debug("Generate complete")
 
     def _pre_package(self, build_path):
-        f = TemporaryFile("w+b")
+        f = TemporaryFile("w+b")  # pylint: disable=consider-using-with
 
         with zipfile.ZipFile(f, mode="w") as zip_file:
             self._recursive_relative_write(build_path, build_path, zip_file)

--- a/src/setup.py
+++ b/src/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="cloudformation-cli-python-lib",
-    version="2.1.5",
+    version="2.1.6",
     description=__doc__,
     author="Amazon Web Services",
     author_email="aws-cloudformation-developers@amazon.com",


### PR DESCRIPTION
copying https://github.com/aws-cloudformation/cloudformation-cli-python-plugin/pull/144/

---

blocked on https://github.com/aws-cloudformation/cloudformation-cli/pull/762 being released