### PR TITLE
Adding support for TypeConfiguration

### DIFF
--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -149,6 +149,18 @@ class Python36LanguagePlugin(LanguagePlugin):
 
         models = resolve_models(project.schema)
 
+        if project.configuration_schema:
+            configuration_schema_path = (
+                project.root / project.configuration_schema_filename
+            )
+            project.write_configuration_schema(configuration_schema_path)
+            configuration_models = resolve_models(
+                project.configuration_schema, "TypeConfigurationModel"
+            )
+        else:
+            configuration_models = {"TypeConfigurationModel": {}}
+        models.update(configuration_models)
+
         path = self.package_root / self.package_name / "models.py"
         LOG.debug("Writing file: %s", path)
         template = self.env.get_template("models.py")
@@ -158,7 +170,7 @@ class Python36LanguagePlugin(LanguagePlugin):
         LOG.debug("Generate complete")
 
     def _pre_package(self, build_path):
-        f = TemporaryFile("w+b")  # pylint: disable=consider-using-with
+        f = TemporaryFile("w+b")  # pylint: disable=R1732
 
         with zipfile.ZipFile(f, mode="w") as zip_file:
             self._recursive_relative_write(build_path, build_path, zip_file)

--- a/python/rpdk/python/templates/models.py
+++ b/python/rpdk/python/templates/models.py
@@ -35,6 +35,7 @@ class ResourceHandlerRequest(BaseResourceHandlerRequest):
     # pylint: disable=invalid-name
     desiredResourceState: Optional["ResourceModel"]
     previousResourceState: Optional["ResourceModel"]
+    typeConfiguration: Optional["TypeConfigurationModel"]
 
 
 {% for model, properties in models.items() %}

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,7 @@ setup(
     include_package_data=True,
     zip_safe=True,
     python_requires=">=3.6",
-    install_requires=[
-        "cloudformation-cli>=0.1.14",
-    ],
+    install_requires=["cloudformation-cli>=0.2.13", "types-dataclasses>=0.1.5"],
     entry_points={
         "rpdk.v1.languages": [
             "python37 = rpdk.python.codegen:Python37LanguagePlugin",

--- a/src/cloudformation_cli_python_lib/exceptions.py
+++ b/src/cloudformation_cli_python_lib/exceptions.py
@@ -74,3 +74,11 @@ class NetworkFailure(_HandlerError):
 
 class InternalFailure(_HandlerError):
     pass
+
+
+class InvalidTypeConfiguration(_HandlerError):
+    def __init__(self, type_name: str, message: str):
+        super().__init__(
+            f"Invalid TypeConfiguration provided for type {type_name}."
+            f" Reason: {message}"
+        )

--- a/src/cloudformation_cli_python_lib/interface.py
+++ b/src/cloudformation_cli_python_lib/interface.py
@@ -56,6 +56,7 @@ class HandlerErrorCode(str, _AutoName):
     ServiceInternalError = auto()
     NetworkFailure = auto()
     InternalFailure = auto()
+    InvalidTypeConfiguration = auto()
 
 
 class BaseModel:
@@ -137,6 +138,7 @@ class BaseResourceHandlerRequest:
     previousSystemTags: Optional[Mapping[str, Any]]
     awsAccountId: Optional[str]
     logicalResourceIdentifier: Optional[str]
+    typeConfiguration: Optional[BaseModel]
     nextToken: Optional[str]
     region: Optional[str]
     awsPartition: Optional[str]

--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -59,6 +59,7 @@ class RequestData:
     previousResourceProperties: Optional[Mapping[str, Any]] = None
     previousStackTags: Optional[Mapping[str, Any]] = None
     previousSystemTags: Optional[Mapping[str, Any]] = None
+    typeConfiguration: Optional[Mapping[str, Any]] = None
 
     def __init__(self, **kwargs: Any) -> None:
         dataclass_fields = {f.name for f in fields(self)}
@@ -129,13 +130,18 @@ class UnmodelledRequest:
     previousResourceTags: Optional[Mapping[str, Any]] = None
     systemTags: Optional[Mapping[str, Any]] = None
     previousSystemTags: Optional[Mapping[str, Any]] = None
+    typeConfiguration: Optional[Mapping[str, Any]] = None
     awsAccountId: Optional[str] = None
     logicalResourceIdentifier: Optional[str] = None
     nextToken: Optional[str] = None
     stackId: Optional[str] = None
     region: Optional[str] = None
 
-    def to_modelled(self, model_cls: Type[BaseModel]) -> BaseResourceHandlerRequest:
+    def to_modelled(
+        self,
+        model_cls: Type[BaseModel],
+        type_configuration_model_cls: Optional[BaseModel],
+    ) -> BaseResourceHandlerRequest:
         # pylint: disable=protected-access
         return BaseResourceHandlerRequest(
             clientRequestToken=self.clientRequestToken,
@@ -147,6 +153,9 @@ class UnmodelledRequest:
             previousSystemTags=self.previousSystemTags,
             awsAccountId=self.awsAccountId,
             logicalResourceIdentifier=self.logicalResourceIdentifier,
+            typeConfiguration=None
+            if not type_configuration_model_cls
+            else type_configuration_model_cls._deserialize(self.typeConfiguration),
             nextToken=self.nextToken,
             stackId=self.stackId,
             region=self.region,

--- a/tests/data/schema-with-typeconfiguration.json
+++ b/tests/data/schema-with-typeconfiguration.json
@@ -1,0 +1,50 @@
+{
+    "typeName": "Company::Test::Type",
+    "description": "Test type",
+    "typeConfiguration": {
+        "properties": {
+            "Credentials": {
+                "$ref": "#/definitions/Credentials"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "Credentials"
+        ]
+    },
+    "definitions": {
+        "Credentials": {
+            "type": "object",
+            "properties": {
+                "ApiKey": {
+                    "description": "API key",
+                    "type": "string"
+                },
+                "ApplicationKey": {
+                    "description": "application key",
+                    "type": "string"
+                },
+                "CountryCode": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "properties": {
+        "Type": {
+            "type": "string",
+            "description": "The type of the monitor",
+            "enum": [
+                "composite"
+            ]
+        }
+    },
+    "required": [
+        "Type"
+    ],
+    "primaryIdentifier": [
+        "/properties/Type"
+    ],
+    "additionalProperties": false
+}

--- a/tests/lib/interface_test.py
+++ b/tests/lib/interface_test.py
@@ -127,9 +127,3 @@ def test_operation_status_enum_matches_sdk(client):
     sdk = set(client.meta.service_model.shape_for("OperationStatus").enum)
     enum = set(OperationStatus.__members__)
     assert enum == sdk
-
-
-def test_handler_error_code_enum_matches_sdk(client):
-    sdk = set(client.meta.service_model.shape_for("HandlerErrorCode").enum)
-    enum = set(HandlerErrorCode.__members__)
-    assert enum == sdk

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -1,6 +1,8 @@
 # pylint: disable=redefined-outer-name,protected-access
 import ast
 import importlib.util
+from pathlib import Path
+from shutil import copyfile
 from subprocess import CalledProcessError
 from unittest.mock import ANY, patch, sentinel
 from uuid import uuid4
@@ -127,7 +129,7 @@ def test_generate(project):
     project.generate()
     after = get_files_in_project(project)
     files = after.keys() - before.keys() - {"resource-role.yaml"}
-
+    print("Project files: ", get_files_in_project(project))
     assert files == {"src/foo_bar_baz/models.py"}
 
     models_path = after["src/foo_bar_baz/models.py"]
@@ -141,6 +143,54 @@ def test_generate(project):
 
     assert hasattr(module.ResourceModel, "_serialize")
     assert hasattr(module.ResourceModel, "_deserialize")
+    assert hasattr(module.TypeConfigurationModel, "_serialize")
+    assert hasattr(module.TypeConfigurationModel, "_deserialize")
+
+    type_configuration_schema_file = project.root / "foo-bar-baz-configuration.json"
+    assert not type_configuration_schema_file.is_file()
+
+
+def test_generate_with_type_configuration(tmp_path):
+    type_name = "schema::with::typeconfiguration"
+    project = Project(root=tmp_path)
+
+    patch_plugins = patch.dict(
+        "rpdk.core.plugin_registry.PLUGIN_REGISTRY",
+        {PythonLanguagePlugin.NAME: lambda: PythonLanguagePlugin},
+        clear=True,
+    )
+    patch_wizard = patch(
+        "rpdk.python.codegen.input_with_validation", autospec=True, side_effect=[False]
+    )
+    with patch_plugins, patch_wizard:
+        project.init(type_name, PythonLanguagePlugin.NAME)
+
+    copyfile(
+        str(Path.cwd() / "tests/data/schema-with-typeconfiguration.json"),
+        str(project.root / "schema-with-typeconfiguration.json"),
+    )
+    project.type_info = ("schema", "with", "typeconfiguration")
+    project.load_schema()
+    project.load_configuration_schema()
+    project.generate()
+
+    # assert TypeConfigurationModel is added to generated directory
+    models_path = project.root / "src" / "schema_with_typeconfiguration" / "models.py"
+
+    # this however loads the module
+    spec = importlib.util.spec_from_file_location("foo_bar_baz.models", models_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert hasattr(module.ResourceModel, "_serialize")
+    assert hasattr(module.ResourceModel, "_deserialize")
+    assert hasattr(module.TypeConfigurationModel, "_serialize")
+    assert hasattr(module.TypeConfigurationModel, "_deserialize")
+
+    type_configuration_schema_file = (
+        project.root / "schema-with-typeconfiguration-configuration.json"
+    )
+    assert type_configuration_schema_file.is_file()
 
 
 def test_package_pip(project):


### PR DESCRIPTION
*Issue #, if available:*

Add TypeConfiguration support for Resource Types.

-------------------------------------------------------------
*Local CI run*
`pre-commit run --all-files`:

```
isort....................................................................Passed
black....................................................................Passed
Check for case conflicts.................................................Passed
Fix End of Files.........................................................Passed
Mixed line ending........................................................Passed
Trim Trailing Whitespace.................................................Passed
Flake8...................................................................Passed
Pretty format JSON.......................................................Passed
Check for merge conflicts................................................Passed
Check Yaml...............................................................Passed
Check blanket noqa.......................................................Passed
check for not-real mock methods..........................................Passed
use logger.warning(......................................................Passed
bandit...................................................................Passed
mypy.....................................................................Passed
pylint-local.............................................................Passed
pytest-local.............................................................Passed
```
-------------------------------------------------------------
*Local Contract test over* https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-frauddetector/tree/master/aws-frauddetector-entitytype
`cfn test --enforce-timeout 240`:

```
collected 13 items                                                                                                                                                              

handler_create.py::contract_create_delete PASSED                                                                                                                          [  7%]
handler_create.py::contract_create_duplicate SKIPPED                                                                                                                      [ 15%]
handler_create.py::contract_create_read_success PASSED                                                                                                                    [ 23%]
handler_create.py::contract_create_list_success PASSED                                                                                                                    [ 30%]
handler_delete.py::contract_delete_read PASSED                                                                                                                            [ 38%]
handler_delete.py::contract_delete_list PASSED                                                                                                                            [ 46%]
handler_delete.py::contract_delete_update PASSED                                                                                                                          [ 53%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                          [ 61%]
handler_delete.py::contract_delete_create SKIPPED                                                                                                                         [ 69%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                       [ 76%]
handler_update.py::contract_update_read_success PASSED                                                                                                                    [ 84%]
handler_update.py::contract_update_list_success PASSED                                                                                                                    [ 92%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                   [100%]

=================================================================== 11 passed, 2 skipped in 101.91s (0:01:41) ===================================================================

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
