### PR TITLE
Fix typing of `type_configuration_model_cls`

### DIFF
--- a/src/cloudformation_cli_python_lib/resource.py
+++ b/src/cloudformation_cli_python_lib/resource.py
@@ -60,7 +60,7 @@ class Resource:
         self,
         type_name: str,
         resouce_model_cls: Type[BaseModel],
-        type_configuration_model_cls: Optional[BaseModel] = None,
+        type_configuration_model_cls: Optional[Type[BaseModel]] = None,
     ) -> None:
         self.type_name = type_name
         self._model_cls: Type[BaseModel] = resouce_model_cls


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `Resource` constructor expects the class of the type configuration, not an instance of it. Fix the type checking.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
