### PR TITLE
Add Session Object to SessionProxy

### DIFF
--- a/src/cloudformation_cli_python_lib/boto3_proxy.py
+++ b/src/cloudformation_cli_python_lib/boto3_proxy.py
@@ -10,6 +10,7 @@ class SessionProxy:
     def __init__(self, session: Session):
         self.client = session.client
         self.resource = session.resource
+        self.session = session
 
 
 def _get_boto_session(

--- a/src/cloudformation_cli_python_lib/log_delivery.py
+++ b/src/cloudformation_cli_python_lib/log_delivery.py
@@ -90,7 +90,7 @@ class ProviderLogHandler(logging.Handler):
             self.client.exceptions.DataAlreadyAcceptedException,
             self.client.exceptions.InvalidSequenceTokenException,
         ) as e:
-            self.sequence_token = str(e).split(" ")[-1]
+            self.sequence_token = str(e).rsplit(" ", maxsplit=1)[-1]
             self._put_log_event(msg)
 
     def emit(self, record: logging.LogRecord) -> None:

--- a/tests/lib/boto3_proxy_test.py
+++ b/tests/lib/boto3_proxy_test.py
@@ -1,3 +1,6 @@
+import botocore
+from boto3.session import Session
+
 from cloudformation_cli_python_lib.boto3_proxy import SessionProxy, _get_boto_session
 from cloudformation_cli_python_lib.utils import Credentials
 
@@ -10,3 +13,13 @@ def test_get_boto_session_returns_proxy():
 def test_get_boto_session_returns_none():
     proxy = _get_boto_session(None)
     assert proxy is None
+
+def test_can_create_boto_client():
+    proxy = _get_boto_session(Credentials("", "", ""))
+    client = proxy.client('s3', region_name="us-west-2") # just in case AWS_REGION not set in test environment
+    assert isinstance(client, botocore.client.BaseClient)
+
+def test_can_retrieve_boto_session():
+    proxy = _get_boto_session(Credentials("", "", ""))
+    session = proxy.session
+    assert isinstance(session, Session)

--- a/tests/lib/boto3_proxy_test.py
+++ b/tests/lib/boto3_proxy_test.py
@@ -1,8 +1,8 @@
-import botocore
 from boto3.session import Session
-
 from cloudformation_cli_python_lib.boto3_proxy import SessionProxy, _get_boto_session
 from cloudformation_cli_python_lib.utils import Credentials
+
+import botocore  # pylint: disable=C0411
 
 
 def test_get_boto_session_returns_proxy():
@@ -14,10 +14,14 @@ def test_get_boto_session_returns_none():
     proxy = _get_boto_session(None)
     assert proxy is None
 
+
 def test_can_create_boto_client():
     proxy = _get_boto_session(Credentials("", "", ""))
-    client = proxy.client('s3', region_name="us-west-2") # just in case AWS_REGION not set in test environment
+    client = proxy.client(
+        "s3", region_name="us-west-2"
+    )  # just in case AWS_REGION not set in test environment
     assert isinstance(client, botocore.client.BaseClient)
+
 
 def test_can_retrieve_boto_session():
     proxy = _get_boto_session(Credentials("", "", ""))


### PR DESCRIPTION
Allows for the user of the plugin to retrieve the boto3 Session object
and use it directly as needed.

*Issue #, if available:* #151

*Description of changes:* Add `session` object to `SessionProxy` class to allow direct use.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
