### PR TITLE
Added a method to provide plugin information that is included in artifact zip

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
   - id: bandit
     files: ^(src|python)/
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.711
+  rev: v0.790
   hooks:
   - id: mypy
     files: ^src/

--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -15,6 +15,7 @@ from rpdk.core.init import input_with_validation
 from rpdk.core.jsonutils.resolver import ContainerType, resolve_models
 from rpdk.core.plugin_base import LanguagePlugin
 
+from . import __version__
 from .resolver import contains_model, translate_type
 
 LOG = logging.getLogger(__name__)
@@ -169,6 +170,10 @@ class Python36LanguagePlugin(LanguagePlugin):
 
         LOG.debug("Generate complete")
 
+    # pylint: disable=unused-argument
+    def get_plugin_information(self, project):
+        return self._get_plugin_information()
+
     def _pre_package(self, build_path):
         f = TemporaryFile("w+b")  # pylint: disable=R1732
 
@@ -232,6 +237,10 @@ class Python36LanguagePlugin(LanguagePlugin):
             "--target",
             str(base_path / "build"),
         ]
+
+    @staticmethod
+    def _get_plugin_information():
+        return {"plugin-tool-version": __version__, "plugin-name": "python"}
 
     @classmethod
     def _docker_build(cls, external_path):

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,8 @@ exclude =
 max-complexity = 10
 max-line-length = 88
 select = C,E,F,W,B,B950
-# C812, C815, W503 clash with black, F723 false positive
-ignore = E501,C812,C815,C816,W503,F723
+# C812, C815, E203, W503 clash with black, F723 false positive
+ignore = E203,E501,C812,C815,C816,W503,F723
 
 [isort]
 line_length = 88

--- a/src/cloudformation_cli_python_lib/recast.py
+++ b/src/cloudformation_cli_python_lib/recast.py
@@ -14,7 +14,7 @@ def recast_object(
     if not isinstance(json_data, dict):
         raise InvalidRequest(f"Can only parse dict items, not {type(json_data)}")
     # if type is Any, we leave it as is
-    if cls == typing.Any:
+    if cls is typing.Any:
         return
     for k, v in json_data.items():
         if isinstance(v, dict):
@@ -35,7 +35,7 @@ def recast_object(
 
 def _recast_lists(cls: Any, k: str, v: List[Any], classes: Dict[str, Any]) -> List[Any]:
     # Leave as is if type is Any
-    if cls == typing.Any:
+    if cls is typing.Any:
         return v
     if "__dataclass_fields__" not in dir(cls):
         pass
@@ -64,7 +64,7 @@ def cast_sequence_item(cls: Any, k: str, item: Any, classes: Dict[str, Any]) -> 
 
 
 def _recast_primitive(cls: Any, k: str, v: Any) -> Any:
-    if cls == typing.Any:
+    if cls is typing.Any:
         # If the type is Any, we cannot guess what the original type was, so we leave
         # it as a string
         return v
@@ -127,5 +127,5 @@ def get_forward_ref_type() -> Any:
     # introspection is valid:
     # https://docs.python.org/3/library/typing.html#typing.ForwardRef
     if "ForwardRef" in dir(typing):
-        return typing.ForwardRef  # type: ignore
+        return typing.ForwardRef
     return typing._ForwardRef  # type: ignore

--- a/tests/lib/resource_test.py
+++ b/tests/lib/resource_test.py
@@ -61,7 +61,7 @@ def resource():
 
 def patch_and_raise(resource, str_to_patch, exc_cls, entrypoint):
     with patch.object(resource, str_to_patch) as mock_parse:
-        mock_parse.side_effect = exc_cls("hahaha")
+        mock_parse.side_effect = exc_cls("exception")
         # "un-apply" decorator
         event = entrypoint.__wrapped__(resource, {}, None)  # pylint: disable=no-member
     return event

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -290,11 +290,66 @@ def test__docker_build_good_path(plugin, tmp_path):
     )
 
 
-def test_get_plugin_information(project):
+def test_get_plugin_information_format1(project):
     plugin_information = project._plugin.get_plugin_information(project)
 
     assert plugin_information["plugin-tool-version"] == __version__
     assert plugin_information["plugin-name"] == "python"
+    assert plugin_information["plugin-version"] == "2.1.3"
+
+
+def test_get_plugin_information_format2(project):
+    existing_content = ""
+    with open(project.root / "requirements.txt", "r+") as f:
+        existing_content = f.read()
+        f.seek(0)
+        f.write("cloudformation-cli-python-lib>=2.1.3; python_version < '3.8'")
+        f.truncate()
+
+    plugin_information = project._plugin.get_plugin_information(project)
+
+    with open(project.root / "requirements.txt", "w") as f:
+        f.write(existing_content)
+
+    assert plugin_information["plugin-tool-version"] == __version__
+    assert plugin_information["plugin-name"] == "python"
+    assert plugin_information["plugin-version"] == "2.1.3"
+
+
+def test_get_plugin_information_format3(project):
+    existing_content = ""
+    with open(project.root / "requirements.txt", "r+") as f:
+        existing_content = f.read()
+        f.seek(0)
+        f.write("dummy_line\ncloudformation-cli-python-lib; python_version < '3.8'")
+        f.truncate()
+
+    plugin_information = project._plugin.get_plugin_information(project)
+
+    with open(project.root / "requirements.txt", "w") as f:
+        f.write(existing_content)
+
+    assert plugin_information["plugin-tool-version"] == __version__
+    assert plugin_information["plugin-name"] == "python"
+    assert "plugin-version" not in plugin_information
+
+
+def test_get_plugin_information_no_support_lib(project):
+    existing_content = ""
+    with open(project.root / "requirements.txt", "r+") as f:
+        existing_content = f.read()
+        f.seek(0)
+        f.write("dummy_line1\ndummy_line2")
+        f.truncate()
+
+    plugin_information = project._plugin.get_plugin_information(project)
+
+    with open(project.root / "requirements.txt", "w") as f:
+        f.write(existing_content)
+
+    assert plugin_information["plugin-tool-version"] == __version__
+    assert plugin_information["plugin-name"] == "python"
+    assert "plugin-version" not in plugin_information
 
 
 @pytest.mark.parametrize(

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -14,6 +14,7 @@ from docker.errors import APIError, ContainerError, ImageLoadError
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from rpdk.core.exceptions import DownstreamError
 from rpdk.core.project import Project
+from rpdk.python.__init__ import __version__
 from rpdk.python.codegen import (
     SUPPORT_LIB_NAME,
     SUPPORT_LIB_PKG,
@@ -287,6 +288,13 @@ def test__docker_build_good_path(plugin, tmp_path):
         stream=True,
         user=ANY,
     )
+
+
+def test_get_plugin_information(project):
+    plugin_information = project._plugin.get_plugin_information(project)
+
+    assert plugin_information["plugin-tool-version"] == __version__
+    assert plugin_information["plugin-name"] == "python"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Description of changes:*
 Added a method to provide plugin information that is included in artifact zip.
Plugin information includes,
- plugin-tool-version - The version of the cli tool 
- plugin-name - "java"/"python"/"go". Here it is "python"
- plugin-version - The version of the runtime lib the project is using.

I used information from the pip [Requirement Specifiers](https://pip.pypa.io/en/stable/cli/pip_install/#requirement-specifiers) document to write the parsing logic to fetch the "plugin-version" from the project's requirements.txt file.

I also updated the mypy version and made few other changes based on pre-commit run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
