### PR TITLE
Add support for Hooks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,6 @@
 [MASTER]
 
-ignore=CVS,models.py,handlers.py
+ignore=CVS,models.py,handlers.py,hook_models.py,hook_handlers.py,target_model.py
 jobs=1
 persistent=yes
 

--- a/python/rpdk/python/__init__.py
+++ b/python/rpdk/python/__init__.py
@@ -1,5 +1,5 @@
 import logging
 
-__version__ = "2.1.4"
+__version__ = "2.1.5"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/python/rpdk/python/templates/hook_handlers.py
+++ b/python/rpdk/python/templates/hook_handlers.py
@@ -1,0 +1,98 @@
+import logging
+from typing import Any, MutableMapping, Optional
+
+from {{support_lib_pkg}} import (
+    BaseHookHandlerRequest,
+    HandlerErrorCode,
+    Hook,
+    HookInvocationPoint,
+    OperationStatus,
+    ProgressEvent,
+    SessionProxy,
+    exceptions,
+)
+
+from .models import HookHandlerRequest, TypeConfigurationModel
+
+# Use this logger to forward log messages to CloudWatch Logs.
+LOG = logging.getLogger(__name__)
+TYPE_NAME = "{{ type_name }}"
+
+hook = Hook(TYPE_NAME, TypeConfigurationModel)
+test_entrypoint = hook.test_entrypoint
+
+
+@hook.handler(HookInvocationPoint.CREATE_PRE_PROVISION)
+def pre_create_handler(
+        session: Optional[SessionProxy],
+        request: HookHandlerRequest,
+        callback_context: MutableMapping[str, Any],
+        type_configuration: TypeConfigurationModel
+) -> ProgressEvent:
+    target_model = request.hookContext.targetModel
+    progress: ProgressEvent = ProgressEvent(
+        status=OperationStatus.IN_PROGRESS
+    )
+    # TODO: put code here
+
+    # Example:
+    try:
+        # Reading the Resource Hook's target properties
+        resource_properties = target_model.get("resourceProperties")
+
+        if isinstance(session, SessionProxy):
+            client = session.client("s3")
+        # Setting Status to success will signal to cfn that the hook operation is complete
+        progress.status = OperationStatus.SUCCESS
+    except TypeError as e:
+        # exceptions module lets CloudFormation know the type of failure that occurred
+        raise exceptions.InternalFailure(f"was not expecting type {e}")
+        # this can also be done by returning a failed progress event
+        # return ProgressEvent.failed(HandlerErrorCode.InternalFailure, f"was not expecting type {e}")
+
+    return progress
+
+
+@hook.handler(HookInvocationPoint.UPDATE_PRE_PROVISION)
+def pre_update_handler(
+        session: Optional[SessionProxy],
+        request: BaseHookHandlerRequest,
+        callback_context: MutableMapping[str, Any],
+        type_configuration: TypeConfigurationModel
+) -> ProgressEvent:
+    target_model = request.hookContext.targetModel
+    progress: ProgressEvent = ProgressEvent(
+        status=OperationStatus.IN_PROGRESS
+    )
+    # TODO: put code here
+
+    # Example:
+    try:
+        # A Hook that does not allow a resource's encryption algorithm to be modified
+
+        # Reading the Resource Hook's target current properties and previous properties
+        resource_properties = target_model.get("resourceProperties")
+        previous_properties = target_model.get("previousResourceProperties")
+
+        if resource_properties.get("encryptionAlgorithm") != previous_properties.get("encryptionAlgorithm"):
+            progress.status = OperationStatus.FAILED
+            progress.message = "Encryption algorithm can not be changed"
+        else:
+            progress.status = OperationStatus.SUCCESS
+    except TypeError as e:
+        progress = ProgressEvent.failed(HandlerErrorCode.InternalFailure, f"was not expecting type {e}")
+
+    return progress
+
+
+@hook.handler(HookInvocationPoint.DELETE_PRE_PROVISION)
+def pre_delete_handler(
+        session: Optional[SessionProxy],
+        request: BaseHookHandlerRequest,
+        callback_context: MutableMapping[str, Any],
+        type_configuration: TypeConfigurationModel
+) -> ProgressEvent:
+    # TODO: put code here
+    return ProgressEvent(
+        status=OperationStatus.SUCCESS
+    )

--- a/python/rpdk/python/templates/hook_models.py
+++ b/python/rpdk/python/templates/hook_models.py
@@ -1,0 +1,78 @@
+# DO NOT modify this file by hand, changes will be overwritten
+import sys
+from dataclasses import dataclass
+from inspect import getmembers, isclass
+from typing import (
+    AbstractSet,
+    Any,
+    Generic,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+)
+
+from cloudformation_cli_python_lib.interface import BaseHookHandlerRequest, BaseModel
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+T = TypeVar("T")
+
+
+def set_or_none(value: Optional[Sequence[T]]) -> Optional[AbstractSet[T]]:
+    if value:
+        return set(value)
+    return None
+
+
+@dataclass
+class HookHandlerRequest(BaseHookHandlerRequest):
+    pass
+
+
+{% for model, properties in models.items() %}
+@dataclass
+class {{ model }}(BaseModel):
+    {% for name, type in properties.items() %}
+    {{ name }}: Optional[{{ type|translate_type }}]
+    {% endfor %}
+
+    @classmethod
+    def _deserialize(
+        cls: Type["_{{ model }}"],
+        json_data: Optional[Mapping[str, Any]],
+    ) -> Optional["_{{ model }}"]:
+        if not json_data:
+            return None
+        {% if model.endswith("ResourceModel") %}
+        dataclasses = {n: o for n, o in getmembers(sys.modules[__name__]) if isclass(o)}
+        recast_object(cls, json_data, dataclasses)
+        {% endif %}
+        return cls(
+            {% for name, type in properties.items() %}
+            {% set container = type.container %}
+            {% set resolved_type = type.type %}
+            {% if container == ContainerType.MODEL %}
+            {{ name }}={{ resolved_type }}._deserialize(json_data.get("{{ name }}")),
+            {% elif container == ContainerType.SET %}
+            {{ name }}=set_or_none(json_data.get("{{ name }}")),
+            {% elif container == ContainerType.LIST %}
+            {% if type | contains_model %}
+            {{name}}=deserialize_list(json_data.get("{{ name }}"), {{resolved_type.type}}),
+            {% else %}
+            {{ name }}=json_data.get("{{ name }}"),
+            {% endif %}
+            {% else %}
+            {{ name }}=json_data.get("{{ name }}"),
+            {% endif %}
+            {% endfor %}
+        )
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_{{ model }} = {{ model }}
+
+
+{% endfor -%}

--- a/python/rpdk/python/templates/requirements.txt
+++ b/python/rpdk/python/templates/requirements.txt
@@ -1,1 +1,1 @@
-{{ support_lib_name }}>=2.1.3
+{{ support_lib_name }}>=2.1.9

--- a/python/rpdk/python/templates/target_model.py
+++ b/python/rpdk/python/templates/target_model.py
@@ -1,0 +1,77 @@
+# DO NOT modify this file by hand, changes will be overwritten
+import sys
+from dataclasses import dataclass
+from inspect import getmembers, isclass
+from typing import (
+    AbstractSet,
+    Any,
+    Generic,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+)
+
+from cloudformation_cli_python_lib.interface import BaseModel
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+T = TypeVar("T")
+
+
+def set_or_none(value: Optional[Sequence[T]]) -> Optional[AbstractSet[T]]:
+    if value:
+        return set(value)
+    return None
+
+
+{% for model, properties in models.items() %}
+@dataclass
+class {{ model }}(BaseModel):
+    {% for name, type in properties.items() %}
+    {{ name }}: Optional[{{ type|translate_type }}]
+    {% endfor %}
+
+    @classmethod
+    def _deserialize(
+        cls: Type["_{{ model }}"],
+        json_data: Optional[Mapping[str, Any]],
+    ) -> Optional["_{{ model }}"]:
+        if not json_data:
+            return None
+        {% if model == (target_name) %}
+        data = dict(filter(lambda e: e[0] in cls.__dataclass_fields__, json_data.items()))
+        if not data:
+            return None
+
+        dataclasses = {n: o for n, o in getmembers(sys.modules[__name__]) if isclass(o)}
+        recast_object(cls, data, dataclasses)
+        {% endif %}
+        return cls(
+            {% for name, type in properties.items() %}
+            {% set container = type.container %}
+            {% set resolved_type = type.type %}
+            {% if container == ContainerType.MODEL %}
+            {{ name }}={{ resolved_type }}._deserialize(json_data.get("{{ name }}")),
+            {% elif container == ContainerType.SET %}
+            {{ name }}=set_or_none(json_data.get("{{ name }}")),
+            {% elif container == ContainerType.LIST %}
+            {% if type | contains_model %}
+            {{name}}=deserialize_list(json_data.get("{{ name }}"), {{resolved_type.type}}),
+            {% else %}
+            {{ name }}=json_data.get("{{ name }}"),
+            {% endif %}
+            {% else %}
+            {{ name }}=json_data.get("{{ name }}"),
+            {% endif %}
+            {% endfor %}
+        )
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_{{ model }} = {{ model }}
+
+
+{% endfor -%}

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     include_package_data=True,
     zip_safe=True,
     python_requires=">=3.6",
-    install_requires=["cloudformation-cli>=0.2.13", "types-dataclasses>=0.1.5"],
+    install_requires=["cloudformation-cli>=0.2.23", "types-dataclasses>=0.1.5"],
     entry_points={
         "rpdk.v1.languages": [
             "python37 = rpdk.python.codegen:Python37LanguagePlugin",

--- a/src/cloudformation_cli_python_lib/__init__.py
+++ b/src/cloudformation_cli_python_lib/__init__.py
@@ -1,10 +1,16 @@
 import logging
 
 from .boto3_proxy import SessionProxy  # noqa: F401
+from .hook import Hook  # noqa: F401
 from .interface import (  # noqa: F401
     Action,
+    BaseHookHandlerRequest,
     BaseResourceHandlerRequest,
     HandlerErrorCode,
+    HookContext,
+    HookInvocationPoint,
+    HookProgressEvent,
+    HookStatus,
     OperationStatus,
     ProgressEvent,
 )

--- a/src/cloudformation_cli_python_lib/cipher.py
+++ b/src/cloudformation_cli_python_lib/cipher.py
@@ -1,0 +1,101 @@
+import base64
+import json
+import uuid
+from typing import Optional
+
+import boto3  # type: ignore
+
+import aws_encryption_sdk  # type: ignore
+from aws_encryption_sdk.exceptions import AWSEncryptionSDKClientError  # type: ignore
+from aws_encryption_sdk.identifiers import CommitmentPolicy  # type: ignore
+from botocore.client import BaseClient  # type: ignore
+from botocore.config import Config  # type: ignore
+from botocore.credentials import (  # type: ignore
+    DeferredRefreshableCredentials,
+    create_assume_role_refresher,
+)
+from botocore.session import Session, get_session  # type: ignore
+
+from .utils import Credentials
+
+
+class Cipher:
+    def decrypt_credentials(
+        self, encrypted_credentials: str
+    ) -> Optional[Credentials]:  # pragma: no cover
+        raise NotImplementedError()
+
+
+class KmsCipher(Cipher):
+    """
+    This class is decrypted the encrypted credentials sent by CFN in the request:
+        * Credentials are encrypted service side
+        * The encrypted credentials along with an IAM role
+        * Credentials are decrypetd using the AWS Encryption
+          SDK while assuming the encryption role
+    """
+
+    def __init__(
+        self, encryption_key_arn: Optional[str], encryption_key_role: Optional[str]
+    ) -> None:
+        self._crypto_client = aws_encryption_sdk.EncryptionSDKClient(
+            commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT
+        )
+        self._key_provider = None
+        if encryption_key_arn and encryption_key_role:
+            self._key_provider = aws_encryption_sdk.StrictAwsKmsMasterKeyProvider(
+                key_ids=[encryption_key_arn],
+                botocore_session=self._get_assume_role_session(
+                    encryption_key_role, self._create_client()
+                ),
+            )
+
+    def decrypt_credentials(
+        self, encrypted_credentials: Optional[str]
+    ) -> Optional[Credentials]:
+        if not encrypted_credentials:
+            return None
+
+        # If no kms key and role arn provided
+        # Attempt to deserialize unencrypted credentials
+        # This happens during contract tests
+        if not self._key_provider:
+            try:
+                credentials_data = json.loads(encrypted_credentials)
+                return Credentials(**credentials_data)
+            except json.JSONDecodeError:
+                return None
+
+        try:
+            decrypted_credentials, _decryptor_header = self._crypto_client.decrypt(
+                source=base64.b64decode(encrypted_credentials),
+                key_provider=self._key_provider,
+            )
+            credentials_data = json.loads(decrypted_credentials.decode("UTF-8"))
+
+            return Credentials(**credentials_data)
+        except (json.JSONDecodeError, AWSEncryptionSDKClientError) as e:
+            raise RuntimeError("Failed to decrypt credentials.") from e
+
+    @staticmethod
+    def _get_assume_role_session(
+        encryption_key_role: str, client: BaseClient
+    ) -> Session:
+        params = {"RoleArn": encryption_key_role, "RoleSessionName": str(uuid.uuid4())}
+
+        session = get_session()
+        # pylint: disable=protected-access
+        session._credentials = DeferredRefreshableCredentials(
+            refresh_using=create_assume_role_refresher(client, params),
+            method="sts-assume-role",
+        )
+        return session
+
+    @staticmethod
+    def _create_client() -> BaseClient:
+        return boto3.client(
+            "sts",
+            config=Config(
+                connect_timeout=10, read_timeout=60, retries={"max_attempts": 3}
+            ),
+        )

--- a/src/cloudformation_cli_python_lib/exceptions.py
+++ b/src/cloudformation_cli_python_lib/exceptions.py
@@ -82,3 +82,19 @@ class InvalidTypeConfiguration(_HandlerError):
             f"Invalid TypeConfiguration provided for type {type_name}."
             f" Reason: {message}"
         )
+
+
+class HandlerInternalFailure(_HandlerError):
+    pass
+
+
+class NonCompliant(_HandlerError):
+    def __init__(self, type_name: str, message: str):
+        super().__init__(
+            f"Hook of type '{type_name}' returned a Non-Complaint status."
+            f" Reason: {message}"
+        )
+
+
+class Unknown(_HandlerError):
+    pass

--- a/src/cloudformation_cli_python_lib/hook.py
+++ b/src/cloudformation_cli_python_lib/hook.py
@@ -1,0 +1,307 @@
+import json
+import logging
+import traceback
+from datetime import datetime
+from functools import wraps
+from typing import Any, Callable, MutableMapping, Optional, Tuple, Type, Union
+
+from .boto3_proxy import SessionProxy, _get_boto_session
+from .cipher import Cipher, KmsCipher
+from .exceptions import InternalFailure, InvalidRequest, _HandlerError
+from .interface import (
+    BaseHookHandlerRequest,
+    HandlerErrorCode,
+    HookInvocationPoint,
+    HookProgressEvent,
+    HookStatus,
+    OperationStatus,
+    ProgressEvent,
+)
+from .log_delivery import HookProviderLogHandler
+from .metrics import MetricsPublisherProxy
+from .utils import (
+    BaseModel,
+    Credentials,
+    HookInvocationRequest,
+    HookTestEvent,
+    KitchenSinkEncoder,
+    LambdaContext,
+    UnmodelledHookRequest,
+)
+
+LOG = logging.getLogger(__name__)
+
+HandlerSignature = Callable[
+    [Optional[SessionProxy], Any, MutableMapping[str, Any], Any], ProgressEvent
+]
+
+
+def _ensure_serialize(
+    entrypoint: Callable[
+        [Any, MutableMapping[str, Any], Any],
+        Union[ProgressEvent, MutableMapping[str, Any]],
+    ]
+) -> Callable[[Any, MutableMapping[str, Any], Any], Any]:
+    @wraps(entrypoint)
+    def wrapper(self: Any, event: MutableMapping[str, Any], context: Any) -> Any:
+        try:
+            response = entrypoint(self, event, context)
+            serialized = json.dumps(response, cls=KitchenSinkEncoder)
+        except Exception:  # pylint: disable=broad-except
+            return Hook._create_progress_response(  # pylint: disable=protected-access
+                ProgressEvent.failed(HandlerErrorCode.InternalFailure),
+                None,
+            )._serialize()
+        return json.loads(serialized)
+
+    return wrapper
+
+
+class Hook:
+    def __init__(
+        self, type_name: str, type_configuration_model_cls: Type[BaseModel]
+    ) -> None:
+        self.type_name = type_name
+        self._type_configuration_model_cls: Type[
+            BaseModel
+        ] = type_configuration_model_cls
+        self._handlers: MutableMapping[HookInvocationPoint, HandlerSignature] = {}
+
+    def handler(
+        self, invocation_point: HookInvocationPoint
+    ) -> Callable[[HandlerSignature], HandlerSignature]:
+        def _add_handler(f: HandlerSignature) -> HandlerSignature:
+            self._handlers[invocation_point] = f
+            return f
+
+        return _add_handler
+
+    def _invoke_handler(  # pylint: disable=too-many-arguments
+        self,
+        session: Optional[SessionProxy],
+        request: BaseHookHandlerRequest,
+        invocation_point: HookInvocationPoint,
+        callback_context: MutableMapping[str, Any],
+        type_configuration: Optional[BaseModel],
+    ) -> ProgressEvent:
+        try:
+            handler = self._handlers[invocation_point]
+        except KeyError:
+            return ProgressEvent.failed(
+                HandlerErrorCode.InternalFailure, f"No handler for {invocation_point}"
+            )
+
+        return handler(session, request, callback_context, type_configuration)
+
+    def _parse_test_request(
+        self, event_data: MutableMapping[str, Any]
+    ) -> Tuple[
+        Optional[SessionProxy],
+        BaseHookHandlerRequest,
+        HookInvocationPoint,
+        MutableMapping[str, Any],
+        Optional[BaseModel],
+    ]:
+        try:
+            event = HookTestEvent(**event_data)
+            creds = Credentials(**event.credentials)
+            request: BaseHookHandlerRequest = UnmodelledHookRequest(
+                **event.request
+            ).to_modelled()
+
+            session = _get_boto_session(creds, event.region)
+            invocation_point = HookInvocationPoint[event.actionInvocationPoint]
+        except Exception as e:  # pylint: disable=broad-except
+            LOG.exception("Invalid request")
+            raise InternalFailure(f"{e} ({type(e).__name__})") from e
+        return (
+            session,
+            request,
+            invocation_point,
+            event.callbackContext or {},
+            # pylint: disable=protected-access
+            None
+            if not self._type_configuration_model_cls
+            else self._type_configuration_model_cls._deserialize(
+                event.typeConfiguration or {}
+            ),
+        )
+
+    @_ensure_serialize
+    def test_entrypoint(
+        self, event: MutableMapping[str, Any], _context: Any
+    ) -> ProgressEvent:
+        msg = "Uninitialized"
+        try:
+            (
+                session,
+                request,
+                invocation_point,
+                callback_context,
+                type_configuration,
+            ) = self._parse_test_request(event)
+            return self._invoke_handler(
+                session, request, invocation_point, callback_context, type_configuration
+            )
+        except _HandlerError as e:
+            LOG.exception("Handler error")
+            return e.to_progress_event()
+        except Exception:  # pylint: disable=broad-except
+            LOG.exception("Exception caught")
+        except BaseException:  # pylint: disable=broad-except
+            LOG.critical("Base exception caught (this is usually bad)", exc_info=True)
+        return ProgressEvent.failed(HandlerErrorCode.InternalFailure, msg)
+
+    @staticmethod
+    def _parse_request(
+        event_data: MutableMapping[str, Any]
+    ) -> Tuple[
+        Tuple[Optional[SessionProxy], Optional[SessionProxy]],
+        HookInvocationPoint,
+        MutableMapping[str, Any],
+        HookInvocationRequest,
+    ]:
+        try:
+            event = HookInvocationRequest.deserialize(event_data)
+            cipher: Cipher = KmsCipher(
+                event.requestData.hookEncryptionKeyArn,
+                event.requestData.hookEncryptionKeyRole,
+            )
+
+            caller_credentials = cipher.decrypt_credentials(
+                event.requestData.callerCredentials
+            )
+            provider_credentials = cipher.decrypt_credentials(
+                event.requestData.providerCredentials
+            )
+
+            caller_sess = _get_boto_session(caller_credentials)
+            provider_sess = _get_boto_session(provider_credentials)
+            # credentials are used when rescheduling, so can't zero them out (for now)
+            invocation_point = HookInvocationPoint[event.actionInvocationPoint]
+            callback_context = event.requestContext.callbackContext or {}
+        except Exception as e:
+            LOG.exception("Invalid request")
+            raise InvalidRequest(f"{e} ({type(e).__name__})") from e
+
+        return ((caller_sess, provider_sess)), invocation_point, callback_context, event
+
+    def _cast_hook_request(
+        self, request: HookInvocationRequest
+    ) -> Tuple[BaseHookHandlerRequest, Optional[BaseModel]]:
+        try:
+            handler_request = UnmodelledHookRequest(
+                clientRequestToken=request.clientRequestToken,
+                awsAccountId=request.awsAccountId,
+                stackId=request.stackId,
+                changeSetId=request.changeSetId,
+                hookTypeName=request.hookTypeName,
+                hookTypeVersion=request.hookTypeVersion,
+                invocationPoint=HookInvocationPoint[request.actionInvocationPoint],
+                targetName=request.requestData.targetName,
+                targetType=request.requestData.targetType,
+                targetLogicalId=request.requestData.targetLogicalId,
+                targetModel=request.requestData.targetModel,
+            ).to_modelled()
+            # pylint: disable=protected-access
+            type_configuration = self._type_configuration_model_cls._deserialize(
+                request.hookModel or {}
+            )
+
+            return handler_request, type_configuration
+
+        except Exception as e:  # pylint: disable=broad-except
+            LOG.exception("Invalid request")
+            raise InvalidRequest(f"{e} ({type(e).__name__})") from e
+
+    # TODO: refactor to reduce branching and locals
+    @_ensure_serialize  # noqa: C901
+    def __call__(  # pylint: disable=too-many-locals  # noqa: C901
+        self, event_data: MutableMapping[str, Any], context: LambdaContext
+    ) -> MutableMapping[str, Any]:
+        logs_setup = False
+
+        def print_or_log(message: str) -> None:
+            if logs_setup:
+                LOG.exception(message, exc_info=True)
+            else:
+                print(message)
+                traceback.print_exc()
+
+        event: Optional[HookInvocationRequest] = None
+        try:
+            sessions, invocation_point, callback, event = self._parse_request(
+                event_data
+            )
+            caller_sess, provider_sess = sessions
+
+            request, type_configuration = self._cast_hook_request(event)
+
+            metrics = MetricsPublisherProxy()
+            if event.requestData.providerLogGroupName and provider_sess:
+                HookProviderLogHandler.setup(event, provider_sess)
+                logs_setup = True
+                metrics.add_hook_metrics_publisher(
+                    provider_sess, event.hookTypeName, event.awsAccountId
+                )
+
+            metrics.publish_invocation_metric(datetime.utcnow(), invocation_point)
+            start_time = datetime.utcnow()
+            error = None
+
+            try:
+                progress = self._invoke_handler(
+                    caller_sess, request, invocation_point, callback, type_configuration
+                )
+            except Exception as e:  # pylint: disable=broad-except
+                error = e
+
+            m_secs = (datetime.utcnow() - start_time).total_seconds() * 1000.0
+            metrics.publish_duration_metric(datetime.utcnow(), invocation_point, m_secs)
+            if error:
+                metrics.publish_exception_metric(
+                    datetime.utcnow(), invocation_point, error
+                )
+                raise error
+        except _HandlerError as e:
+            print_or_log("Handler error")
+            progress = e.to_progress_event()
+        except Exception as e:  # pylint: disable=broad-except
+            print_or_log("Exception caught {0}".format(e))
+            progress = ProgressEvent.failed(HandlerErrorCode.InternalFailure)
+        except BaseException as e:  # pylint: disable=broad-except
+            print_or_log("Base exception caught (this is usually bad) {0}".format(e))
+            progress = ProgressEvent.failed(HandlerErrorCode.InternalFailure)
+
+        # use the raw event_data as a last-ditch attempt to call back if the
+        # request is invalid
+        return self._create_progress_response(
+            progress, event
+        )._serialize()  # pylint: disable=protected-access
+
+    @staticmethod
+    def _create_progress_response(
+        progress_event: ProgressEvent, request: Optional[HookInvocationRequest]
+    ) -> HookProgressEvent:
+        response = HookProgressEvent(Hook._get_hook_status(progress_event.status))
+        response.result = progress_event.result
+        response.message = progress_event.message
+        response.errorCode = progress_event.errorCode
+        response.callbackContext = progress_event.callbackContext
+        response.callbackDelaySeconds = progress_event.callbackDelaySeconds
+        response.errorCode = progress_event.errorCode
+        if request:
+            response.clientRequestToken = request.clientRequestToken
+        return response
+
+    @staticmethod
+    def _get_hook_status(operation_status: OperationStatus) -> HookStatus:
+        if operation_status == OperationStatus.PENDING:
+            hook_status = HookStatus.PENDING
+        elif operation_status == OperationStatus.IN_PROGRESS:
+            hook_status = HookStatus.IN_PROGRESS
+        elif operation_status == OperationStatus.SUCCESS:
+            hook_status = HookStatus.SUCCESS
+        else:
+            hook_status = HookStatus.FAILED
+        return hook_status

--- a/src/cloudformation_cli_python_lib/metrics.py
+++ b/src/cloudformation_cli_python_lib/metrics.py
@@ -1,11 +1,11 @@
 import datetime
 import logging
-from typing import Any, List, Mapping, Optional
+from typing import Any, List, Mapping, Optional, Union
 
 from botocore.exceptions import ClientError  # type: ignore
 
 from .boto3_proxy import SessionProxy
-from .interface import Action, MetricTypes, StandardUnit
+from .interface import Action, HookInvocationPoint, MetricTypes, StandardUnit
 
 LOG = logging.getLogger(__name__)
 
@@ -134,6 +134,91 @@ class MetricsPublisher:
         return f"{METRIC_NAMESPACE_ROOT}/{suffix}"
 
 
+class HookMetricsPublisher(MetricsPublisher):
+    def __init__(self, session: SessionProxy, hook_type: str, account_id: str) -> None:
+        super().__init__(session, hook_type)
+        self._hook_type = hook_type
+        self._account_id = account_id
+        self._namespace = self._make_hook_namespace(hook_type, account_id)
+
+    # pylint: disable=arguments-differ
+    def publish_exception_metric(  # type: ignore
+        self,
+        timestamp: datetime.datetime,
+        invocation_point: HookInvocationPoint,
+        error: Any,
+    ) -> None:
+        dimensions: Mapping[str, str] = {
+            "DimensionKeyInvocationPointType": invocation_point.name,
+            "DimensionKeyExceptionType": str(type(error)),
+            "DimensionKeyHookType": self._hook_type,
+        }
+        self.publish_metric(
+            metric_name=MetricTypes.HandlerException,
+            dimensions=dimensions,
+            unit=StandardUnit.Count,
+            value=1.0,
+            timestamp=timestamp,
+        )
+
+    # pylint: disable=arguments-differ
+    def publish_invocation_metric(  # type: ignore
+        self, timestamp: datetime.datetime, invocation_point: HookInvocationPoint
+    ) -> None:
+        dimensions = {
+            "DimensionKeyInvocationPointType": invocation_point.name,
+            "DimensionKeyHookType": self._hook_type,
+        }
+        self.publish_metric(
+            metric_name=MetricTypes.HandlerInvocationCount,
+            dimensions=dimensions,
+            unit=StandardUnit.Count,
+            value=1.0,
+            timestamp=timestamp,
+        )
+
+    # pylint: disable=arguments-differ
+    def publish_duration_metric(  # type: ignore
+        self,
+        timestamp: datetime.datetime,
+        invocation_point: HookInvocationPoint,
+        milliseconds: float,
+    ) -> None:
+        dimensions = {
+            "DimensionKeyInvocationPointType": invocation_point.name,
+            "DimensionKeyHookType": self._hook_type,
+        }
+
+        self.publish_metric(
+            metric_name=MetricTypes.HandlerInvocationDuration,
+            dimensions=dimensions,
+            unit=StandardUnit.Milliseconds,
+            value=milliseconds,
+            timestamp=timestamp,
+        )
+
+    def publish_log_delivery_exception_metric(
+        self, timestamp: datetime.datetime, error: Any
+    ) -> None:
+        dimensions = {
+            "DimensionKeyInvocationPointType": "ProviderLogDelivery",
+            "DimensionKeyExceptionType": str(type(error)),
+            "DimensionKeyHookType": self._hook_type,
+        }
+        self.publish_metric(
+            metric_name=MetricTypes.HandlerException,
+            dimensions=dimensions,
+            unit=StandardUnit.Count,
+            value=1.0,
+            timestamp=timestamp,
+        )
+
+    @staticmethod
+    def _make_hook_namespace(hook_type: str, account_id: str) -> str:
+        suffix = hook_type.replace("::", "/")
+        return f"{METRIC_NAMESPACE_ROOT}/{account_id}/{suffix}"
+
+
 class MetricsPublisherProxy:
     """A proxy for publishing metrics to multiple publishers. \
     Iterates over available publishers and publishes.
@@ -164,23 +249,42 @@ class MetricsPublisherProxy:
             publisher = MetricsPublisher(session, type_name)
             self._publishers.append(publisher)
 
+    def add_hook_metrics_publisher(
+        self,
+        session: Optional[SessionProxy],
+        type_name: Optional[str],
+        account_id: Optional[str],
+    ) -> None:
+        if session and type_name and account_id:
+            publisher = HookMetricsPublisher(session, type_name, account_id)
+            self._publishers.append(publisher)
+
     def publish_exception_metric(
-        self, timestamp: datetime.datetime, action: Action, error: Any
+        self,
+        timestamp: datetime.datetime,
+        action: Union[Action, HookInvocationPoint],
+        error: Any,
     ) -> None:
         for publisher in self._publishers:
-            publisher.publish_exception_metric(timestamp, action, error)
+            publisher.publish_exception_metric(timestamp, action, error)  # type: ignore
 
     def publish_invocation_metric(
-        self, timestamp: datetime.datetime, action: Action
+        self, timestamp: datetime.datetime, action: Union[Action, HookInvocationPoint]
     ) -> None:
         for publisher in self._publishers:
-            publisher.publish_invocation_metric(timestamp, action)
+            publisher.publish_invocation_metric(timestamp, action)  # type: ignore
 
+    # pylint: disable=line-too-long
     def publish_duration_metric(
-        self, timestamp: datetime.datetime, action: Action, milliseconds: float
+        self,
+        timestamp: datetime.datetime,
+        action: Union[Action, HookInvocationPoint],
+        milliseconds: float,
     ) -> None:
+        # fmt off
         for publisher in self._publishers:
-            publisher.publish_duration_metric(timestamp, action, milliseconds)
+            publisher.publish_duration_metric(timestamp, action, milliseconds)  # type: ignore
+        # fmt on
 
     def publish_log_delivery_exception_metric(
         self, timestamp: datetime.datetime, error: Any

--- a/src/cloudformation_cli_python_lib/resource.py
+++ b/src/cloudformation_cli_python_lib/resource.py
@@ -227,6 +227,9 @@ class Resource:
             print_or_log("Base exception caught (this is usually bad) {0}".format(e))
             progress = ProgressEvent.failed(HandlerErrorCode.InternalFailure)
 
+        if progress.result:
+            progress.result = None
+
         # use the raw event_data as a last-ditch attempt to call back if the
         # request is invalid
         return progress._serialize()  # pylint: disable=protected-access

--- a/src/setup.py
+++ b/src/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="cloudformation-cli-python-lib",
-    version="2.1.8",
+    version="2.1.9",
     description=__doc__,
     author="Amazon Web Services",
     author_email="aws-cloudformation-developers@amazon.com",

--- a/src/setup.py
+++ b/src/setup.py
@@ -13,7 +13,11 @@ setup(
     include_package_data=True,
     zip_safe=True,
     python_requires=">=3.6",
-    install_requires=["boto3>=1.10.20", 'dataclasses;python_version<"3.7"'],
+    install_requires=[
+        "boto3>=1.10.20",
+        "aws-encryption-sdk==2.0.0",
+        'dataclasses;python_version<"3.7"',
+    ],
     license="Apache License 2.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tests/lib/cipher_test.py
+++ b/tests/lib/cipher_test.py
@@ -1,0 +1,105 @@
+# pylint: disable=wrong-import-order,line-too-long
+from unittest.mock import Mock, patch
+
+import pytest
+from cloudformation_cli_python_lib.cipher import KmsCipher
+from cloudformation_cli_python_lib.utils import Credentials
+
+from aws_encryption_sdk.exceptions import AWSEncryptionSDKClientError
+
+
+def mock_session():
+    return Mock(spec_set=["client"])
+
+
+def test_create_kms_cipher():
+    with patch(
+        "cloudformation_cli_python_lib.cipher.aws_encryption_sdk.StrictAwsKmsMasterKeyProvider",
+        autospec=True,
+    ):
+        cipher = KmsCipher("encryptionKeyArn", "encryptionKeyRole")
+    assert cipher
+
+
+def test_decrypt_credentials_success():
+    expected_credentials = {
+        "accessKeyId": "IASAYK835GAIFHAHEI23",
+        "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5poh2O0",
+        "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DH"
+        "fW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg",
+    }
+
+    with patch(
+        "cloudformation_cli_python_lib.cipher.aws_encryption_sdk.StrictAwsKmsMasterKeyProvider",
+        autospec=True,
+    ), patch(
+        "cloudformation_cli_python_lib.cipher.aws_encryption_sdk.EncryptionSDKClient.decrypt"
+    ) as mock_decrypt:
+        mock_decrypt.return_value = (
+            b'{"accessKeyId": "IASAYK835GAIFHAHEI23", "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5poh2O0", "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"}',  # noqa: B950
+            Mock(),
+        )
+        cipher = KmsCipher("encryptionKeyArn", "encryptionKeyRole")
+
+        credentials = cipher.decrypt_credentials(
+            "ewogICAgICAgICAgICAiYWNjZXNzS2V5SWQiOiAiSUFTQVlLODM1R0FJRkhBSEVJMjMiLAogICAg"
+        )
+    assert Credentials(**expected_credentials) == credentials
+
+
+def test_decrypt_credentials_fail():
+    with patch(
+        "cloudformation_cli_python_lib.cipher.aws_encryption_sdk.StrictAwsKmsMasterKeyProvider",
+        autospec=True,
+    ), patch(
+        "cloudformation_cli_python_lib.cipher.aws_encryption_sdk.EncryptionSDKClient.decrypt"
+    ) as mock_decrypt, pytest.raises(
+        RuntimeError
+    ) as excinfo:
+        mock_decrypt.side_effect = AWSEncryptionSDKClientError()
+        cipher = KmsCipher("encryptionKeyArn", "encryptionKeyRole")
+        cipher.decrypt_credentials(
+            "ewogICAgICAgICAgICAiYWNjZXNzS2V5SWQiOiAiSUFTQVlLODM1R0FJRkhBSEVJMjMiLAogICAg"
+        )
+    assert str(excinfo.value) == "Failed to decrypt credentials."
+
+
+@pytest.mark.parametrize(
+    "encryption_key_arn,encryption_key_role",
+    [
+        (None, "encryptionKeyRole"),
+        ("encryptionKeyArn", None),
+        (None, None),
+    ],
+)
+def test_decrypt_unencrypted_credentials_success(
+    encryption_key_arn, encryption_key_role
+):
+    expected_credentials = {
+        "accessKeyId": "IASAYK835GAIFHAHEI23",
+        "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5poh2O0",
+        "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DH"
+        "fW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg",
+    }
+
+    cipher = KmsCipher(encryption_key_arn, encryption_key_role)
+
+    credentials = cipher.decrypt_credentials(
+        '{"accessKeyId": "IASAYK835GAIFHAHEI23", "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5poh2O0", "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"}'  # noqa: B950
+    )
+    assert Credentials(**expected_credentials) == credentials
+
+
+@pytest.mark.parametrize(
+    "encryption_key_arn,encryption_key_role",
+    [
+        (None, "encryptionKeyRole"),
+        ("encryptionKeyArn", None),
+        (None, None),
+    ],
+)
+def test_decrypt_unencrypted_credentials_fail(encryption_key_arn, encryption_key_role):
+    cipher = KmsCipher(encryption_key_arn, encryption_key_role)
+
+    credentials = cipher.decrypt_credentials("{ Not JSON")  # noqa: B950
+    assert not credentials

--- a/tests/lib/hook_test.py
+++ b/tests/lib/hook_test.py
@@ -1,0 +1,469 @@
+# pylint: disable=redefined-outer-name,protected-access,line-too-long
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from unittest.mock import Mock, call, patch, sentinel
+
+import pytest
+from cloudformation_cli_python_lib import Hook
+from cloudformation_cli_python_lib.exceptions import InternalFailure, InvalidRequest
+from cloudformation_cli_python_lib.hook import _ensure_serialize
+from cloudformation_cli_python_lib.interface import (
+    BaseModel,
+    HandlerErrorCode,
+    HookInvocationPoint,
+    HookProgressEvent,
+    HookStatus,
+    OperationStatus,
+    ProgressEvent,
+)
+from cloudformation_cli_python_lib.utils import Credentials, HookInvocationRequest
+
+ENTRYPOINT_PAYLOAD = {
+    "awsAccountId": "123456789012",
+    "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    "region": "us-east-1",
+    "actionInvocationPoint": "CREATE_PRE_PROVISION",
+    "hookTypeName": "AWS::Test::TestHook",
+    "hookTypeVersion": "1.0",
+    "requestContext": {
+        "invocation": 1,
+        "callbackContext": {},
+    },
+    "requestData": {
+        "callerCredentials": '{"accessKeyId": "IASAYK835GAIFHAHEI23", "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5poh2O0", "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"}',  # noqa: B950
+        "providerCredentials": '{"accessKeyId": "HDI0745692Y45IUTYR78", "secretAccessKey": "4976TUYVI2345GW87ERYG823RF87GY9EIUH452I3", "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"}',  # noqa: B950
+        "providerLogGroupName": "providerLoggingGroupName",
+        "targetName": "AWS::Test::Resource",
+        "targetType": "RESOURCE",
+        "targetLogicalId": "myResource",
+        "hookEncryptionKeyArn": None,
+        "hookEncryptionKeyRole": None,
+        "targetModel": {
+            "resourceProperties": sentinel.resource_properties,
+            "previousResourceProperties": sentinel.previous_resource_properties,
+        },
+    },
+    "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e"
+    "722ae60-fe62-11e8-9a0e-0ae8cc519968",
+    "hookModel": sentinel.type_configuration,
+}
+
+
+TYPE_NAME = "Test::Foo::Bar"
+
+
+@pytest.fixture
+def hook():
+    return Hook(TYPE_NAME, Mock)
+
+
+def patch_and_raise(hook, str_to_patch, exc_cls, entrypoint):
+    with patch.object(hook, str_to_patch) as mock_parse:
+        mock_parse.side_effect = exc_cls("hahaha")
+        # "un-apply" decorator
+        event = entrypoint.__wrapped__(hook, {}, None)  # pylint: disable=no-member
+    return event
+
+
+def test_entrypoint_handler_error(hook):
+    with patch("cloudformation_cli_python_lib.hook.HookProviderLogHandler.setup"):
+        event = hook.__call__.__wrapped__(hook, {}, None)  # pylint: disable=no-member
+    assert event["hookStatus"] == HookStatus.FAILED.value
+    assert event["errorCode"] == HandlerErrorCode.InvalidRequest
+
+
+def test_entrypoint_success():
+    hook = Hook(TYPE_NAME, Mock())
+    event = ProgressEvent(status=OperationStatus.SUCCESS, message="")
+    mock_handler = hook.handler(HookInvocationPoint.CREATE_PRE_PROVISION)(
+        Mock(return_value=event)
+    )
+
+    with patch(
+        "cloudformation_cli_python_lib.hook.HookProviderLogHandler.setup"
+    ) as mock_log_delivery, patch(
+        "cloudformation_cli_python_lib.hook.KmsCipher.decrypt_credentials"
+    ) as mock_cipher:
+        mock_cipher.side_effect = lambda c: Credentials(**json.loads(c))
+        event = hook.__call__.__wrapped__(  # pylint: disable=no-member
+            hook, ENTRYPOINT_PAYLOAD, None
+        )
+    mock_log_delivery.assert_called_once()
+
+    assert event == {
+        "hookStatus": HookStatus.SUCCESS.name,  # pylint: disable=no-member
+        "message": "",
+        "callbackDelaySeconds": 0,
+        "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    }
+
+    mock_handler.assert_called_once()
+
+
+def test_entrypoint_handler_raises():
+    @dataclass
+    class TypeConfigurationModel(BaseModel):
+        a_string: str
+
+        @classmethod
+        def _deserialize(cls, json_data):
+            return cls("test")
+
+    hook = Hook(Mock(), TypeConfigurationModel)
+
+    with patch(
+        "cloudformation_cli_python_lib.hook.HookProviderLogHandler.setup"
+    ), patch(
+        "cloudformation_cli_python_lib.hook.MetricsPublisherProxy"
+    ) as mock_metrics, patch(
+        "cloudformation_cli_python_lib.hook.Hook._invoke_handler"
+    ) as mock__invoke_handler, patch(
+        "cloudformation_cli_python_lib.hook.KmsCipher.decrypt_credentials"
+    ) as mock_cipher:
+        mock__invoke_handler.side_effect = InvalidRequest("handler failed")
+        mock_cipher.side_effect = lambda c: Credentials(**json.loads(c))
+        event = hook.__call__.__wrapped__(  # pylint: disable=no-member
+            hook, ENTRYPOINT_PAYLOAD, None
+        )
+
+    mock_metrics.return_value.publish_exception_metric.assert_called_once()
+
+    assert event == {
+        "errorCode": "InvalidRequest",
+        "hookStatus": "FAILED",
+        "message": "handler failed",
+        "callbackDelaySeconds": 0,
+        "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    }
+
+
+def test_entrypoint_with_context():
+    payload = ENTRYPOINT_PAYLOAD.copy()
+    payload["callbackContext"] = {"a": "b"}
+    hook = Hook(TYPE_NAME, Mock())
+    event = ProgressEvent(
+        status=OperationStatus.SUCCESS, message="", callbackContext={"c": "d"}
+    )
+    mock_handler = hook.handler(HookInvocationPoint.CREATE_PRE_PROVISION)(
+        Mock(return_value=event)
+    )
+
+    with patch(
+        "cloudformation_cli_python_lib.hook.HookProviderLogHandler.setup"
+    ), patch(
+        "cloudformation_cli_python_lib.hook.KmsCipher.decrypt_credentials"
+    ) as mock_cipher:
+        mock_cipher.side_effect = lambda c: Credentials(**json.loads(c))
+        hook.__call__.__wrapped__(hook, payload, None)  # pylint: disable=no-member
+
+    mock_handler.assert_called_once()
+
+
+def test_entrypoint_success_without_caller_provider_creds():
+    hook = Hook(TYPE_NAME, Mock())
+    event = ProgressEvent(status=OperationStatus.SUCCESS, message="")
+    hook.handler(HookInvocationPoint.CREATE_PRE_PROVISION)(Mock(return_value=event))
+
+    payload = ENTRYPOINT_PAYLOAD.copy()
+    payload["requestData"] = payload["requestData"].copy()
+
+    expected = {
+        "hookStatus": HookStatus.SUCCESS.name,  # pylint: disable=no-member
+        "message": "",
+        "callbackDelaySeconds": 0,
+        "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    }
+
+    with patch("cloudformation_cli_python_lib.hook.HookProviderLogHandler.setup"):
+        # Credentials are defined in payload, but null
+        payload["requestData"]["providerCredentials"] = None
+        payload["requestData"]["callerCredentials"] = None
+        event = hook.__call__.__wrapped__(  # pylint: disable=no-member
+            hook, payload, None
+        )
+        assert event == expected
+
+        # Credentials are undefined in payload
+        del payload["requestData"]["providerCredentials"]
+        del payload["requestData"]["callerCredentials"]
+
+        event = hook.__call__.__wrapped__(  # pylint: disable=no-member
+            hook, payload, None
+        )
+        assert event == expected
+
+
+def test_cast_hook_request_invalid_request(hook):
+    request = HookInvocationRequest.deserialize(ENTRYPOINT_PAYLOAD)
+    request.requestData = None
+    with pytest.raises(InvalidRequest) as excinfo:
+        hook._cast_hook_request(request)
+
+    assert "AttributeError" in str(excinfo.value)
+
+
+def test__parse_request_valid_request_and__cast_hook_request():
+    mock_type_configuration_model = Mock(spec_set=["_deserialize"])
+    mock_type_configuration_model._deserialize.side_effect = [
+        sentinel.type_configuration
+    ]
+
+    hook = Hook(TYPE_NAME, mock_type_configuration_model)
+
+    with patch(
+        "cloudformation_cli_python_lib.hook._get_boto_session"
+    ) as mock_session, patch(
+        "cloudformation_cli_python_lib.hook.KmsCipher.decrypt_credentials"
+    ) as mock_cipher:
+        mock_cipher.side_effect = lambda c: Credentials(**json.loads(c))
+        ret = hook._parse_request(ENTRYPOINT_PAYLOAD)
+    sessions, invocation_point, callback_context, request = ret
+
+    mock_session.assert_has_calls(
+        [
+            call(
+                Credentials(
+                    **json.loads(ENTRYPOINT_PAYLOAD["requestData"]["callerCredentials"])
+                )
+            ),
+            call(
+                Credentials(
+                    **json.loads(
+                        ENTRYPOINT_PAYLOAD["requestData"]["providerCredentials"]
+                    )
+                )
+            ),
+        ],
+        any_order=True,
+    )
+
+    # credentials are used when rescheduling, so can't zero them out (for now)
+    assert request.requestData.callerCredentials is not None
+    assert request.requestData.providerCredentials is not None
+    assert request.hookModel is sentinel.type_configuration
+
+    caller_sess, provider_sess = sessions
+    assert caller_sess is mock_session.return_value
+    assert provider_sess is mock_session.return_value
+
+    assert invocation_point == HookInvocationPoint.CREATE_PRE_PROVISION
+    assert callback_context == {}
+
+    modeled_request, modeled_type_configuration = hook._cast_hook_request(request)
+
+    mock_type_configuration_model._deserialize.assert_has_calls(
+        [call(sentinel.type_configuration)]
+    )
+    assert modeled_request.clientRequestToken == request.clientRequestToken
+    assert modeled_request.hookContext.targetName == "AWS::Test::Resource"
+    assert (
+        modeled_request.hookContext.targetModel.get("resourceProperties")
+        is sentinel.resource_properties
+    )
+    assert (
+        modeled_request.hookContext.targetModel.get("previousResourceProperties")
+        is sentinel.previous_resource_properties
+    )
+    assert modeled_request.hookContext.targetLogicalId == "myResource"
+    assert modeled_type_configuration is sentinel.type_configuration
+
+
+@pytest.mark.parametrize("exc_cls", [Exception, BaseException])
+def test_entrypoint_uncaught_exception(hook, exc_cls):
+    with patch("cloudformation_cli_python_lib.hook.HookProviderLogHandler.setup"):
+        event = patch_and_raise(hook, "_parse_request", exc_cls, hook.__call__)
+    assert event["hookStatus"] == HookStatus.FAILED
+    assert event["errorCode"] == HandlerErrorCode.InternalFailure
+
+
+def test__ensure_serialize_uses_custom_encoder():
+    now = datetime.now()
+
+    @_ensure_serialize
+    def wrapped(_self, _event, _context):
+        return {"foo": now}
+
+    json = wrapped(None, None, None)
+    assert json == {"foo": now.isoformat()}
+
+
+def test__ensure_serialize_invalid_returns_progress_event():
+    @_ensure_serialize
+    def wrapped(_self, _event, _context):
+        class Unserializable:
+            pass
+
+        return {"foo": Unserializable()}
+
+    serialized = wrapped(None, None, None)
+    event = HookProgressEvent.failed(HandlerErrorCode.InternalFailure)
+    try:
+        # Python 3.7/3.8
+        assert serialized == event._serialize()
+    except AssertionError:
+        # Python 3.6
+        assert serialized == event._serialize()
+
+
+def test_handler_decorator(hook):
+    deco = hook.handler(HookInvocationPoint.CREATE_PRE_PROVISION)
+    assert deco(sentinel.mock_handler) is sentinel.mock_handler
+    assert hook._handlers == {
+        HookInvocationPoint.CREATE_PRE_PROVISION: sentinel.mock_handler
+    }
+
+
+def test__invoke_handler_not_found(hook):
+    actual = hook._invoke_handler(
+        None, None, HookInvocationPoint.CREATE_PRE_PROVISION, {}, None
+    )
+    expected = ProgressEvent.failed(
+        HandlerErrorCode.InternalFailure, "No handler for CREATE_PRE_PROVISION"
+    )
+    assert actual == expected
+
+
+def test__invoke_handler_was_found(hook):
+    progress_event = ProgressEvent(status=OperationStatus.IN_PROGRESS)
+    mock_handler = hook.handler(HookInvocationPoint.CREATE_PRE_PROVISION)(
+        Mock(return_value=progress_event)
+    )
+
+    resp = hook._invoke_handler(
+        sentinel.session,
+        sentinel.request,
+        HookInvocationPoint.CREATE_PRE_PROVISION,
+        sentinel.context,
+        sentinel.type_configuration,
+    )
+    assert resp is progress_event
+    mock_handler.assert_called_once_with(
+        sentinel.session,
+        sentinel.request,
+        sentinel.context,
+        sentinel.type_configuration,
+    )
+
+
+@pytest.mark.parametrize("event,messages", [({}, ("missing", "credentials"))])
+def test__parse_test_request_invalid_request(hook, event, messages):
+    with pytest.raises(InternalFailure) as excinfo:
+        hook._parse_test_request(event)
+
+    for msg in messages:
+        assert msg in str(excinfo.value), msg
+
+
+def test__parse_test_request_valid_request():
+    mock_type_configuration_model = Mock(spec_set=["_deserialize"])
+    mock_type_configuration_model._deserialize.side_effect = [
+        sentinel.type_configuration
+    ]
+
+    payload = {
+        "credentials": {"accessKeyId": "", "secretAccessKey": "", "sessionToken": ""},
+        "actionInvocationPoint": "CREATE_PRE_PROVISION",
+        "request": {
+            "clientRequestToken": "ecba020e-b2e6-4742-a7d0-8a06ae7c4b2b",
+            "hookContext": {
+                "awsAccountId": "123456789012",
+                "targetName": "AWS::Test::Resource",
+                "targetModel": {
+                    "resourceProperties": sentinel.resource_properties,
+                    "previousResourceProperties": sentinel.previous_resource_properties,
+                },
+            },
+        },
+        "callbackContext": None,
+        "typeConfiguration": sentinel.type_configuration,
+    }
+
+    hook = Hook(TYPE_NAME, mock_type_configuration_model)
+
+    with patch("cloudformation_cli_python_lib.hook._get_boto_session") as mock_session:
+        ret = hook._parse_test_request(payload)
+    session, request, invocation_point, callback_context, type_configuration = ret
+
+    mock_session.assert_called_once()
+    assert session is mock_session.return_value
+
+    assert request.clientRequestToken == "ecba020e-b2e6-4742-a7d0-8a06ae7c4b2b"
+    mock_type_configuration_model._deserialize.assert_has_calls(
+        [call(sentinel.type_configuration)]
+    )
+    assert request.hookContext.targetName == "AWS::Test::Resource"
+    assert (
+        request.hookContext.targetModel.get("resourceProperties")
+        is sentinel.resource_properties
+    )
+    assert (
+        request.hookContext.targetModel.get("previousResourceProperties")
+        is sentinel.previous_resource_properties
+    )
+    assert request.hookContext.targetLogicalId is None
+    assert type_configuration is sentinel.type_configuration
+
+    assert invocation_point == HookInvocationPoint.CREATE_PRE_PROVISION
+    assert callback_context == {}
+
+
+def test_test_entrypoint_handler_error(hook):
+    # "un-apply" decorator
+    event = hook.test_entrypoint.__wrapped__(  # pylint: disable=no-member
+        hook, {}, None
+    )
+    assert event.status == OperationStatus.FAILED
+    assert event.errorCode == HandlerErrorCode.InternalFailure
+
+
+@pytest.mark.parametrize("exc_cls", [Exception, BaseException])
+def test_test_entrypoint_uncaught_exception(hook, exc_cls):
+    event = patch_and_raise(hook, "_parse_test_request", exc_cls, hook.test_entrypoint)
+    assert event.status == HookStatus.FAILED
+    assert event.errorCode == HandlerErrorCode.InternalFailure
+
+
+def test_test_entrypoint_success():
+    mock_type_configuration_model = Mock(spec_set=["_deserialize"])
+    mock_type_configuration_model._deserialize.side_effect = [
+        sentinel.type_configuration
+    ]
+
+    hook = Hook(TYPE_NAME, mock_type_configuration_model)
+    progress_event = ProgressEvent(status=OperationStatus.SUCCESS)
+    mock_handler = hook.handler(HookInvocationPoint.CREATE_PRE_PROVISION)(
+        Mock(return_value=progress_event)
+    )
+
+    payload = {
+        "credentials": {"accessKeyId": "", "secretAccessKey": "", "sessionToken": ""},
+        "actionInvocationPoint": "CREATE_PRE_PROVISION",
+        "request": {
+            "clientRequestToken": "ecba020e-b2e6-4742-a7d0-8a06ae7c4b2b",
+        },
+        "typeConfiguration": sentinel.type_configuration,
+    }
+
+    event = hook.test_entrypoint.__wrapped__(  # pylint: disable=no-member
+        hook, payload, None
+    )
+    assert event is progress_event
+
+    mock_type_configuration_model._deserialize.assert_has_calls(
+        [call(sentinel.type_configuration)]
+    )
+    mock_handler.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "operation_status,hook_status",
+    [
+        (OperationStatus.PENDING, HookStatus.PENDING),
+        (OperationStatus.IN_PROGRESS, HookStatus.IN_PROGRESS),
+        (OperationStatus.SUCCESS, HookStatus.SUCCESS),
+        (OperationStatus.FAILED, HookStatus.FAILED),
+    ],
+)
+def test_get_hook_status(operation_status, hook_status):
+    assert hook_status == Hook._get_hook_status(operation_status)

--- a/tests/lib/resource_test.py
+++ b/tests/lib/resource_test.py
@@ -171,6 +171,30 @@ def test_entrypoint_with_context():
     mock_handler.assert_called_once()
 
 
+def test_entrypoint_ignore_remove_fields_from_response():
+    resource = Resource(TYPE_NAME, Mock(), Mock())
+    event = ProgressEvent(
+        status=OperationStatus.SUCCESS, message="", result="Here are the results"
+    )
+    mock_handler = resource.handler(Action.CREATE)(Mock(return_value=event))
+
+    with patch(
+        "cloudformation_cli_python_lib.resource.ProviderLogHandler.setup"
+    ) as mock_log_delivery:
+        event = resource.__call__.__wrapped__(  # pylint: disable=no-member
+            resource, ENTRYPOINT_PAYLOAD, None
+        )
+    mock_log_delivery.assert_called_once()
+
+    assert event == {
+        "message": "",
+        "status": OperationStatus.SUCCESS.name,  # pylint: disable=no-member
+        "callbackDelaySeconds": 0,
+    }
+
+    mock_handler.assert_called_once()
+
+
 def test_entrypoint_success_without_caller_provider_creds():
     resource = Resource(TYPE_NAME, Mock(), Mock())
     event = ProgressEvent(status=OperationStatus.SUCCESS, message="")

--- a/tests/lib/utils_test.py
+++ b/tests/lib/utils_test.py
@@ -145,3 +145,6 @@ def test_deserialize_list_empty():
 def test_deserialize_list_invalid():
     with pytest.raises(InvalidRequest):
         deserialize_list([(1, 2)], BaseModel)
+
+
+# test_hook_response


### PR DESCRIPTION
This release adds support for creating Hooks using the CFN CLI Python plugin
 * Initialize a Hook project with `cfn init --artifact-type HOOK --type-name <type-name>`
 * For example: `cfn init --artifact-type HOOK --type-name My::Test::Example`
 * Using `cfn init` without parameters will now first ask if you want to create a resource,  module, or a hook. If you choose to create a hook, you will be asked to choose a language plugin. After choosing a plugin, a hook project will be generated with boilerplate code which you can use as a starting point to make your changes.
 * Use `cfn validate` to validate your hook before submitting
 * Use `cfn submit` to register your hook, making it available for use by CloudFormation in your AWS account

Related PRs:
* https://github.com/aws-cloudformation/cloudformation-cli/pull/861

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
