### PR TITLE
Adding exception message to return to CFN

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@ exclude: ^(buildspec.yml|.pre-commit-config.yaml)$
 fail_fast: true
 repos:
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.17
+  rev: v5.10.1
   hooks:
   - id: isort
     # language_version: python3.6
 - repo: https://github.com/ambv/black
-  rev: 20.8b1
+  rev: 22.3.0
   hooks:
   - id: black
     exclude: templates/
@@ -38,18 +38,18 @@ repos:
   - id: check-merge-conflict
   - id: check-yaml
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.3.0
+  rev: v1.9.0
   hooks:
   - id: python-check-blanket-noqa
   - id: python-check-mock-methods
   - id: python-no-log-warn
 - repo: https://github.com/PyCQA/bandit
-  rev: "1.6.2"
+  rev: "1.7.4"
   hooks:
   - id: bandit
     files: ^(src|python)/
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.790
+  rev: v0.942
   hooks:
   - id: mypy
     files: ^src/

--- a/src/cloudformation_cli_python_lib/resource.py
+++ b/src/cloudformation_cli_python_lib/resource.py
@@ -222,10 +222,16 @@ class Resource:
             progress = e.to_progress_event()
         except Exception as e:  # pylint: disable=broad-except
             print_or_log("Exception caught {0}".format(e))
-            progress = ProgressEvent.failed(HandlerErrorCode.InternalFailure)
+            progress = ProgressEvent.failed(
+                HandlerErrorCode.InternalFailure,
+                message=str("Exception caught {0}".format(e)),
+            )
         except BaseException as e:  # pylint: disable=broad-except
             print_or_log("Base exception caught (this is usually bad) {0}".format(e))
-            progress = ProgressEvent.failed(HandlerErrorCode.InternalFailure)
+            progress = ProgressEvent.failed(
+                HandlerErrorCode.InternalFailure,
+                message=str("Base exception caught {0}".format(e)),
+            )
 
         if progress.result:
             progress.result = None


### PR DESCRIPTION
Adding message to the progress event for `Exception` and `BaseException` (strongly casted to str) to provide more insights on what the error was on `__call__`

Tested in private resource in CFN (by bunding code manually vs using `cfn submit`). Local sam tests and `aws cloudformation test-type` both pass with the change.