### PR TITLE
Implemented nested dict re-cast

### DIFF
--- a/tests/lib/recast_test.py
+++ b/tests/lib/recast_test.py
@@ -47,6 +47,15 @@ def test_recast_complex_object():
             [{"NestedListInt": "true", "NestedListList": ["1", "2", "3"]}],
             [{"NestedListInt": "false", "NestedListList": ["11", "12", "13"]}],
         ],
+        "NestedObject": {
+            "first_object": {"AttributeA": "AWS_CFN", "AttributeB": "FTW"},
+            "second_object": {"AttributeA": "AllHailPython"},
+            "third_object": {
+                "ListAttribute": ["2.1", "42.0"],
+                "AttributeA": "WeAlsoHaveLists",
+            },
+            "fourth-0bject": {"BoolAttribute": "false", "AttributeB": "ThatIsNotTrue"},
+        },
     }
     expected = {
         "ListSetInt": [{1, 2, 3}],
@@ -79,6 +88,15 @@ def test_recast_complex_object():
             [{"NestedListInt": True, "NestedListList": [1.0, 2.0, 3.0]}],
             [{"NestedListInt": False, "NestedListList": [11.0, 12.0, 13.0]}],
         ],
+        "NestedObject": {
+            "first_object": {"AttributeA": "AWS_CFN", "AttributeB": "FTW"},
+            "second_object": {"AttributeA": "AllHailPython"},
+            "third_object": {
+                "ListAttribute": [2.1, 42.0],
+                "AttributeA": "WeAlsoHaveLists",
+            },
+            "fourth-0bject": {"BoolAttribute": False, "AttributeB": "ThatIsNotTrue"},
+        },
     }
     model = ComplexResourceModel._deserialize(payload)
     assert payload == expected

--- a/tests/lib/sample_model.py
+++ b/tests/lib/sample_model.py
@@ -55,6 +55,7 @@ class ResourceModel(BaseModel):
     HttpsUrl: Optional[str]
     Namespace: Optional[str]
     Id: Optional[int]
+    NestedObject: Optional[MutableMapping[str, "_NestedObjectDefinition"]]
 
     @classmethod
     def _deserialize(
@@ -83,6 +84,7 @@ class ResourceModel(BaseModel):
             HttpsUrl=json_data.get("HttpsUrl"),
             Namespace=json_data.get("Namespace"),
             Id=json_data.get("Id"),
+            NestedObject=json_data.get("NestedObject"),
         )
 
 
@@ -107,6 +109,32 @@ class NestedList(BaseModel):
 
 # work around possible type aliasing issues when variable has same name as a model
 _NestedList = NestedList
+
+
+@dataclass
+class NestedObjectDefinition(BaseModel):
+    AttributeA: Optional[str]
+    AttributeB: Optional[str]
+    BoolAttribute: Optional[bool]
+    ListAttribute: Optional[Sequence[float]]
+
+    @classmethod
+    def _deserialize(
+        cls: Type["_NestedObjectDefinition"],
+        json_data: Optional[Mapping[str, Any]],
+    ) -> Optional["_NestedObjectDefinition"]:
+        if not json_data:
+            return None
+        return cls(
+            AttributeA=json_data.get("AttributeA"),
+            AttributeB=json_data.get("AttributeB"),
+            BoolAttribute=json_data.get("BoolAttribute"),
+            ListAttribute=json_data.get("ListAttribute"),
+        )
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_NestedObjectDefinition = NestedObjectDefinition
 
 
 @dataclass


### PR DESCRIPTION
Related to #172 

When trying to recast dict items, if the key is not found, it will iterate over the "nested" dict items first.
At first, I had 

```python
    except KeyError:
        child_cls = _field_to_type(cls.__dataclass_fields__[k].type, k, classes)
        for _child, _child_definition in v.items():
            recast_object(child_cls, _child_definition, classes)
            _new_child = child_cls._deserialize(_child_definition)
            json_data[k][_child] = _child_definition
```

which works fine. However, then the recast_test would not pass as the type for `json_data[k][_child] ` would be that of `cls` instead of more "primitive" ones.
Drawback to that is that in the handlers code, every object is a `dict` instead of being of type `cls`. which means no access to the object attributes directly.

Welcome for suggestions on how to keep the typing in handlers when using `model` instead of having to deal in pure `dict`

Edit 1:
For the record, for the purpose of handlers, casting the nested value to the correct class, then use it and return to CFN works totally fine. In my CFN resource type I left the code as follows

```python
    except KeyError:
        child_cls = _field_to_type(cls.__dataclass_fields__[k].type, k, classes)
        for _child, _child_definition in v.items():
            recast_object(child_cls, _child_definition, classes)
            _new_child = child_cls._deserialize(_child_definition)
            json_data[k][_child] = _new_child
```

And everything works totally fine.