### PR TITLE
feat: added set handling to KitchenSinkEncoder

### DIFF
--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -29,6 +29,8 @@ class KitchenSinkEncoder(json.JSONEncoder):
     def default(self, o):  # type: ignore  # pylint: disable=method-hidden
         if isinstance(o, (datetime, date, time)):
             return o.isoformat()
+        if isinstance(o, set):
+            return sorted(o)
         try:
             return o._serialize()  # pylint: disable=protected-access
         except AttributeError:

--- a/tests/lib/utils_test.py
+++ b/tests/lib/utils_test.py
@@ -53,6 +53,22 @@ def test_default_unsupported_type_goes_to_base_class():
         json.dumps(Unserializable(), cls=KitchenSinkEncoder)
 
 
+def test_handle_model_with_sets():
+    value = {
+        "callbackDelaySeconds": 0,
+        "message": "",
+        "resourceModel": {"Events": {"event_1", "event_2"}, "Arn": "arn:aws:dummy"},
+        "status": "SUCCESS",
+    }
+
+    assert (
+        json.dumps(value, cls=KitchenSinkEncoder)
+        == '{"callbackDelaySeconds": 0, "message": "", '
+        '"resourceModel": {"Events": ["event_1", "event_2"], '
+        '"Arn": "arn:aws:dummy"}, "status": "SUCCESS"}'
+    )
+
+
 def test_handler_request_serde_roundtrip():
     payload = {
         "awsAccountId": "123456789012",


### PR DESCRIPTION
fixes issue with ensure_serializable failing on Set type

*Description of changes:*

- added set handling to KitchenSinkEncoder, and test function

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
