### PR TITLE
Return AccessDenied Error Code when failing to decrypt credentials

### DIFF
--- a/src/cloudformation_cli_python_lib/exceptions.py
+++ b/src/cloudformation_cli_python_lib/exceptions.py
@@ -98,3 +98,7 @@ class NonCompliant(_HandlerError):
 
 class Unknown(_HandlerError):
     pass
+
+
+class _EncryptionError(Exception):
+    pass


### PR DESCRIPTION
For `HOOK` types, credentials are encrypted service side before invoking the hook. Credentials are decrypted while setting up the runtime before calling the authored handler code.  
  
Sometimes decryption of the credentials fails when customer is missing permissions for decrypting the credentials. This usually happens when customer specifies their own hook execution role.  
  
To avoid this being marked as an `InternalFailure` service side, having the Hook wrapper return an `AccessDenied` error code instead back to CFN whenever decryption of credentials fails


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
