### PR TITLE
Fix condition when no handlers have been defined

### DIFF
--- a/src/cloudformation_cli_python_lib/log_delivery.py
+++ b/src/cloudformation_cli_python_lib/log_delivery.py
@@ -52,7 +52,8 @@ class ProviderLogHandler(logging.Handler):
                 return
             # filter provider messages from platform
             provider = request.resourceType.replace("::", "_").lower()
-            logging.getLogger().handlers[0].addFilter(ProviderFilter(provider))
+            if logging.getLogger().handlers:
+                logging.getLogger().handlers[0].addFilter(ProviderFilter(provider))
             log_handler = cls(
                 group=log_group, stream=stream_name, session=provider_sess
             )

--- a/tests/lib/log_delivery_test.py
+++ b/tests/lib/log_delivery_test.py
@@ -171,6 +171,24 @@ def test_setup_with_provider_creds_without_stack_id(setup_patches, mock_session)
     assert payload.region in plh.stream
 
 
+def test_setup_with_provider_creds_without_stack_id_no_handlers(
+    setup_patches, mock_session
+):
+    payload, _hook_payload, p_logger, p__get_logger, _p__get_hook_logger = setup_patches
+    payload.stackId = None
+    root_logger = logging.getLogger()
+    with p_logger as mock_log, p__get_logger as mock_get:
+        for _ in root_logger.handlers:
+            root_logger.removeHandler(_)
+        mock_get.return_value = None
+        ProviderLogHandler.setup(payload, mock_session)
+    mock_session.client.assert_called_once_with("logs")
+    mock_log.return_value.addHandler.assert_called_once()
+    plh = mock_log.return_value.addHandler.call_args[0][0]
+    assert payload.awsAccountId in plh.stream
+    assert payload.region in plh.stream
+
+
 def test_setup_with_provider_creds_without_logical_resource_id(
     setup_patches, mock_session
 ):


### PR DESCRIPTION
* #171 
* #181 

*Description of changes:*

Lack of validation that there are handlers set at all leads to trying to access at invalid index for the `handlers`.
So, if there are handlers, we can indeed at least access `0` and then add the filter.

I won't pretend to understand why this is here / what's the use-case for it, given that's not documented, but at least with that simple fix my code that works in sam local, in cfn test resource, and now in actually using it in CFN.

I also then now get logs into CloudWatch logs.

Sad note:

Not sure how, if at all,  this passed *real life tests* when working on the new version release.
So that begs the question, for me and anyone who wants to use this library: is it at all tested in CFN or just with cfn test on local lambda ? :/
And especially if not at all, I'd recommend to have beta versions, users notified of these new beta versions for us to test with (which won't affect current working published resource versions either) so that can be tested, and very happy to part take in that.
