### PR TITLE
Update pre-commit dependency to fix GitHub Actions workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,8 @@ repos:
   hooks:
   - id: isort
     # language_version: python3.6
-- repo: https://github.com/ambv/black
-  rev: 20.8b1
+- repo: https://github.com/psf/black
+  rev: 22.3.0
   hooks:
   - id: black
     exclude: templates/


### PR DESCRIPTION
This simply updates black to fix the broken workflow (psf/black#2964).

See [successful workflow](https://github.com/darrylabbate/cloudformation-cli-python-plugin/actions/runs/2092842046) from my fork.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
