### PR TITLE
Move `addFilter()` call after `addHandler()`

### DIFF
--- a/src/cloudformation_cli_python_lib/log_delivery.py
+++ b/src/cloudformation_cli_python_lib/log_delivery.py
@@ -52,12 +52,12 @@ class ProviderLogHandler(logging.Handler):
                 return
             # filter provider messages from platform
             provider = request.resourceType.replace("::", "_").lower()
-            logging.getLogger().handlers[0].addFilter(ProviderFilter(provider))
             log_handler = cls(
                 group=log_group, stream=stream_name, session=provider_sess
             )
             # add log handler to root, so that provider gets plugin logs too
             logging.getLogger().addHandler(log_handler)
+            logging.getLogger().handlers[0].addFilter(ProviderFilter(provider))
 
     def _create_log_group(self) -> None:
         try:


### PR DESCRIPTION
CC:
- #181
- #182

This change avoids an issue where the `logging.getLogger().handlers` list is unconditionally subscripted with index `0`, which can cause an `IndexError` to be thrown if no handlers were previously defined. By moving the `addFilter()` call after the `addHandler()` call, this at least guarantees `handlers[0]` will have been initialized first.

I've gone ahead and tested this change manually against CFN and have found no issues.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
