### PR TITLE
fix: Upgrade aws-encryption-sdk dependency

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -16,6 +16,7 @@ setup(
     install_requires=[
         "boto3>=1.10.20",
         "aws-encryption-sdk==2.2.0",
+        "cryptography>=2.5.0,<37",
         'dataclasses;python_version<"3.7"',
     ],
     license="Apache License 2.0",

--- a/src/setup.py
+++ b/src/setup.py
@@ -15,8 +15,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "boto3>=1.10.20",
-        "aws-encryption-sdk==2.2.0",
-        "cryptography>=2.5.0,<37",
+        "aws-encryption-sdk==3.1.0",
         'dataclasses;python_version<"3.7"',
     ],
     license="Apache License 2.0",


### PR DESCRIPTION
*Description of changes:*

The `cloudformation-cli-python-lib` has a dependency on the `aws-encryption-sdk` for python. The encryption SDK itself has a [dependency on](https://github.com/aws/aws-encryption-sdk-python/blob/master/requirements.txt#L2) the python [`cryptography` library](https://cryptography.io/en/latest/). 
  
Have had some reports on `HOOK` type handler returning this internal error:
```
cannot import name 'int_from_bytes' from 'cryptography.utils' (/var/task/cryptography/utils.py)
```

According the [change log](https://cryptography.io/en/latest/changelog/), version 37.0.0 was recently release and includes some breaking changes.  
  
I have tested using the previous v36 version and the issue is fixed. <s>Adding cyrptography version less than v37 as a requirement for the CFN CLI Python library.</s>

Decided to upgrade the `aws-encryption-sdk` to v3.1.0 instead based on @darrylabbate suggestion. Have tested this change as well.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
