### PR TITLE
Use Amazon ECR images for mimicing lambda with docker

### DIFF
--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -43,6 +43,7 @@ class Python36LanguagePlugin(LanguagePlugin):
     RESOURCE_ENTRY_POINT = "{}.handlers.resource"
     TEST_ENTRY_POINT = "{}.handlers.test_entrypoint"
     CODE_URI = "build/"
+    DOCKER_TAG = 3.6
 
     def __init__(self):
         self.env = self._setup_jinja_env(
@@ -274,7 +275,7 @@ class Python36LanguagePlugin(LanguagePlugin):
         LOG.debug("command is '%s'", command)
 
         volumes = {str(external_path): {"bind": str(internal_path), "mode": "rw"}}
-        image = f"lambci/lambda:build-{cls.RUNTIME}"
+        image = f"public.ecr.aws/lambda/python:{cls.DOCKER_TAG}"
         LOG.warning(
             "Starting Docker build. This may take several minutes if the "
             "image '%s' needs to be pulled first.",
@@ -288,6 +289,7 @@ class Python36LanguagePlugin(LanguagePlugin):
                 auto_remove=True,
                 volumes=volumes,
                 stream=True,
+                entrypoint="",
                 user=f"{os.geteuid()}:{os.getgid()}",
             )
         except RequestsConnectionError as e:
@@ -325,3 +327,4 @@ class Python36LanguagePlugin(LanguagePlugin):
 class Python37LanguagePlugin(Python36LanguagePlugin):
     NAME = "python37"
     RUNTIME = "python3.7"
+    DOCKER_TAG = 3.7

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -438,6 +438,7 @@ def test__docker_build_good_path(plugin, tmp_path):
         auto_remove=True,
         volumes={str(tmp_path): {"bind": "/project", "mode": "rw"}},
         stream=True,
+        entrypoint="",
         user=ANY,
     )
 
@@ -479,5 +480,6 @@ def test__docker_build_bad_path(plugin, tmp_path, exception):
         auto_remove=True,
         volumes={str(tmp_path): {"bind": "/project", "mode": "rw"}},
         stream=True,
+        entrypoint="",
         user=ANY,
     )


### PR DESCRIPTION
*Issue #, if available:*
#192 

*Description of changes:*
- Update the docker images used to leverage public ECR and Amazon published images https://gallery.ecr.aws/lambda/python
- Currently used images don't look to be maintained and can result in rate limiting from docker hub

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
