### PR TITLE
chore(lifecycle) - Add support for to create resource extensions in Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -38,3 +38,7 @@ jobs:
       run: ./e2e-test.sh python36
     - name: End to End Resource Packaging Test Python 3.7
       run: ./e2e-test.sh python37
+    - name: End to End Resource Packaging Test Python 3.8
+      run: ./e2e-test.sh python38
+    - name: End to End Resource Packaging Test Python 3.9
+      run: ./e2e-test.sh python39

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [ 3.6, 3.7, 3.8, 3.9 ]
+        python: [ 3.7, 3.8, 3.9 ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }}

--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -171,7 +171,7 @@ class Python36LanguagePlugin(LanguagePlugin):
 
         if project.configuration_schema:
             configuration_schema_path = (
-                project.root / project.configuration_schema_filename
+                    project.root / project.configuration_schema_filename
             )
             project.write_configuration_schema(configuration_schema_path)
             configuration_models = resolve_models(
@@ -354,3 +354,15 @@ class Python37LanguagePlugin(Python36LanguagePlugin):
     NAME = "python37"
     RUNTIME = "python3.7"
     DOCKER_TAG = 3.7
+
+
+class Python38LanguagePlugin(Python36LanguagePlugin):
+    NAME = "python38"
+    RUNTIME = "python3.8"
+    DOCKER_TAG = 3.8
+
+
+class Python39LanguagePlugin(Python36LanguagePlugin):
+    NAME = "python39"
+    RUNTIME = "python3.9"
+    DOCKER_TAG = 3.9

--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -171,7 +171,7 @@ class Python36LanguagePlugin(LanguagePlugin):
 
         if project.configuration_schema:
             configuration_schema_path = (
-                    project.root / project.configuration_schema_filename
+                project.root / project.configuration_schema_filename
             )
             project.write_configuration_schema(configuration_schema_path)
             configuration_models = resolve_models(

--- a/python/rpdk/python/parser.py
+++ b/python/rpdk/python/parser.py
@@ -27,3 +27,11 @@ def setup_subparser_python36(subparsers, parents):
 
 def setup_subparser_python37(subparsers, parents):
     return setup_subparser(subparsers, parents, "python37")
+
+
+def setup_subparser_python38(subparsers, parents):
+    return setup_subparser(subparsers, parents, "python38")
+
+
+def setup_subparser_python39(subparsers, parents):
+    return setup_subparser(subparsers, parents, "python39")

--- a/python/rpdk/python/parser.py
+++ b/python/rpdk/python/parser.py
@@ -1,9 +1,9 @@
-def setup_subparser(subparsers, parents, python_version):
+def setup_subparser(subparsers, parents, python_version, python_version_number):
     parser = subparsers.add_parser(
         python_version,
-        description="""This sub command generates IDE and build files for Python {}
-            """.format(
-            "3.6" if python_version == "python36" else "3.7"
+        description=(
+            "This sub command generates IDE and build files for Python "
+            "{}".format(python_version_number)
         ),
         parents=parents,
     )
@@ -22,16 +22,16 @@ def setup_subparser(subparsers, parents, python_version):
 
 
 def setup_subparser_python36(subparsers, parents):
-    return setup_subparser(subparsers, parents, "python36")
+    return setup_subparser(subparsers, parents, "python36", "3.6")
 
 
 def setup_subparser_python37(subparsers, parents):
-    return setup_subparser(subparsers, parents, "python37")
+    return setup_subparser(subparsers, parents, "python37", "3.7")
 
 
 def setup_subparser_python38(subparsers, parents):
-    return setup_subparser(subparsers, parents, "python38")
+    return setup_subparser(subparsers, parents, "python38", "3.8")
 
 
 def setup_subparser_python39(subparsers, parents):
-    return setup_subparser(subparsers, parents, "python39")
+    return setup_subparser(subparsers, parents, "python39", "3.9")

--- a/setup.py
+++ b/setup.py
@@ -40,10 +40,14 @@ setup(
     install_requires=["cloudformation-cli>=0.2.26", "types-dataclasses>=0.1.5"],
     entry_points={
         "rpdk.v1.languages": [
+            "python39 = rpdk.python.codegen:Python39LanguagePlugin",
+            "python38 = rpdk.python.codegen:Python38LanguagePlugin",
             "python37 = rpdk.python.codegen:Python37LanguagePlugin",
             "python36 = rpdk.python.codegen:Python36LanguagePlugin",
         ],
         "rpdk.v1.parsers": [
+            "python39 = rpdk.python.parser:setup_subparser_python39",
+            "python38 = rpdk.python.parser:setup_subparser_python38",
             "python37 = rpdk.python.parser:setup_subparser_python37",
             "python36 = rpdk.python.parser:setup_subparser_python36",
         ],

--- a/tests/plugin/parser_test.py
+++ b/tests/plugin/parser_test.py
@@ -1,5 +1,10 @@
 import argparse
-from rpdk.python.parser import setup_subparser_python36, setup_subparser_python37
+from rpdk.python.parser import (
+    setup_subparser_python36,
+    setup_subparser_python37,
+    setup_subparser_python38,
+    setup_subparser_python39,
+)
 
 
 def test_setup_subparser_python36():
@@ -23,4 +28,28 @@ def test_setup_subparser_python37():
     args = sub_parser.parse_args([])
 
     assert args.language == "python37"
+    assert args.use_docker is False
+
+
+def test_setup_subparser_python38():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="subparser_name")
+
+    sub_parser = setup_subparser_python38(subparsers, [])
+
+    args = sub_parser.parse_args([])
+
+    assert args.language == "python38"
+    assert args.use_docker is False
+
+
+def test_setup_subparser_python39():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="subparser_name")
+
+    sub_parser = setup_subparser_python39(subparsers, [])
+
+    args = sub_parser.parse_args([])
+
+    assert args.language == "python39"
     assert args.use_docker is False


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add support for to create resource extensions in Python 3.8 and 3.9
- Remove support for testing on Python 3.6

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
