### PR TITLE
fix(test) - Reduce dependency on AWS config file

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -13,6 +13,7 @@ disable=
     too-few-public-methods,     # triggers when inheriting
     ungrouped-imports,          # clashes with isort
     duplicate-code,             # broken, setup.py
+    wrong-import-order,         # isort has precedence
 
 [BASIC]
 

--- a/tests/lib/boto3_proxy_test.py
+++ b/tests/lib/boto3_proxy_test.py
@@ -2,8 +2,6 @@ from boto3.session import Session
 from cloudformation_cli_python_lib.boto3_proxy import SessionProxy, _get_boto_session
 from cloudformation_cli_python_lib.utils import Credentials
 
-import botocore  # pylint: disable=C0411
-
 
 def test_get_boto_session_returns_proxy():
     proxy = _get_boto_session(Credentials("", "", ""))
@@ -13,14 +11,6 @@ def test_get_boto_session_returns_proxy():
 def test_get_boto_session_returns_none():
     proxy = _get_boto_session(None)
     assert proxy is None
-
-
-def test_can_create_boto_client():
-    proxy = _get_boto_session(Credentials("", "", ""))
-    client = proxy.client(
-        "s3", region_name="us-west-2"
-    )  # just in case AWS_REGION not set in test environment
-    assert isinstance(client, botocore.client.BaseClient)
 
 
 def test_can_retrieve_boto_session():

--- a/tests/lib/cipher_test.py
+++ b/tests/lib/cipher_test.py
@@ -17,7 +17,7 @@ def test_create_kms_cipher():
     with patch(
         "cloudformation_cli_python_lib.cipher.aws_encryption_sdk.StrictAwsKmsMasterKeyProvider",
         autospec=True,
-    ):
+    ), patch("boto3.client", autospec=True):
         cipher = KmsCipher("encryptionKeyArn", "encryptionKeyRole")
     assert cipher
 
@@ -35,7 +35,9 @@ def test_decrypt_credentials_success():
         autospec=True,
     ), patch(
         "cloudformation_cli_python_lib.cipher.aws_encryption_sdk.EncryptionSDKClient.decrypt"
-    ) as mock_decrypt:
+    ) as mock_decrypt, patch(
+        "boto3.client", autospec=True
+    ):
         mock_decrypt.return_value = (
             b'{"accessKeyId": "IASAYK835GAIFHAHEI23", "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5poh2O0", "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"}',  # noqa: B950
             Mock(),
@@ -56,7 +58,9 @@ def test_decrypt_credentials_fail():
         "cloudformation_cli_python_lib.cipher.aws_encryption_sdk.EncryptionSDKClient.decrypt"
     ) as mock_decrypt, pytest.raises(
         _EncryptionError
-    ) as excinfo:
+    ) as excinfo, patch(
+        "boto3.client", autospec=True
+    ):
         mock_decrypt.side_effect = AWSEncryptionSDKClientError()
         cipher = KmsCipher("encryptionKeyArn", "encryptionKeyRole")
         cipher.decrypt_credentials(
@@ -73,7 +77,9 @@ def test_decrypt_credentials_returns_null_fail():
         "cloudformation_cli_python_lib.cipher.aws_encryption_sdk.EncryptionSDKClient.decrypt"
     ) as mock_decrypt, pytest.raises(
         _EncryptionError
-    ) as excinfo:
+    ) as excinfo, patch(
+        "boto3.client", autospec=True
+    ):
         mock_decrypt.return_value = (
             b"null",
             Mock(),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Current versions of tests rely on some information being in `~/.aws/config` when doing mocks. This PR will completely remove that dependency. 

You will have issues with the current version of the tests if you have no `~/.aws/config` or are using the `credential_process` attribute in a profile

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
