### PR TITLE
fix(docker): During `cfn submit` docker commands were not working on Windows

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -5,7 +5,7 @@ name: CloudFormation Python Plugin CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ integrated/oseuid ]
   pull_request:
     branches: [ master ]
 
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
     description: Run pytest in the local virtualenv
     entry: >
       pytest
-      --cov-report=term
+      --cov-report=term-missing
       --cov-report=html
       --cov="rpdk.python"
       --cov="cloudformation_cli_python_lib"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,17 +2,17 @@ exclude: ^(buildspec.yml|.pre-commit-config.yaml)$
 fail_fast: true
 repos:
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.17
+  rev: v5.10.1
   hooks:
   - id: isort
     # language_version: python3.6
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 22.8.0
   hooks:
   - id: black
     exclude: templates/
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.0.0
+  rev: v4.1.0
   hooks:
   - id: check-case-conflict
   - id: end-of-file-fixer
@@ -20,6 +20,16 @@ repos:
     args:
     - --fix=lf
   - id: trailing-whitespace
+  - id: pretty-format-json
+    args:
+    - --autofix
+    - --indent=4
+    - --no-sort-keys
+  - id: check-merge-conflict
+  - id: check-yaml
+- repo: https://github.com/pycqa/flake8
+  rev: "5.0.4"
+  hooks:
   - id: flake8
     additional_dependencies:
     - flake8-bugbear>=19.3.0
@@ -30,28 +40,21 @@ repos:
     - flake8-pep3101>=1.2.1
     # language_version: python3.6
     exclude: templates/
-  - id: pretty-format-json
-    args:
-    - --autofix
-    - --indent=4
-    - --no-sort-keys
-  - id: check-merge-conflict
-  - id: check-yaml
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.3.0
+  rev: v1.9.0
   hooks:
   - id: python-check-blanket-noqa
   - id: python-check-mock-methods
   - id: python-no-log-warn
 - repo: https://github.com/PyCQA/bandit
-  rev: "1.6.2"
+  rev: "1.7.1"
   hooks:
   - id: bandit
     files: ^(src|python)/
     additional_dependencies:
       - "importlib-metadata<5"  # https://github.com/PyCQA/bandit/issues/956
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.790
+  rev: v0.812
   hooks:
   - id: mypy
     files: ^src/

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+
+# Per-module options:
+[mypy-setuptools.*]
+ignore_missing_imports = True

--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -282,8 +282,13 @@ class Python36LanguagePlugin(LanguagePlugin):
     @classmethod
     def _docker_build(cls, external_path):
         internal_path = PurePosixPath("/project")
-        command = '/bin/bash -c "' + ' '.join(_update_pip_command()) + ' && ' + \
-            ' '.join(_make_pip_command(internal_path)) + '"'
+        command = (
+            '/bin/bash -c "'
+            + " ".join(cls._update_pip_command())
+            + " && "
+            + " ".join(cls._make_pip_command(internal_path))
+            + '"'
+        )
         LOG.debug("command is '%s'", command)
 
         volumes = {str(external_path): {"bind": str(internal_path), "mode": "rw"}}

--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -1,14 +1,10 @@
+import docker
 import logging
 import os
 import shutil
 import zipfile
-from pathlib import PurePosixPath
-from subprocess import PIPE, CalledProcessError, run as subprocess_run  # nosec
-from tempfile import TemporaryFile
-from typing import Dict
-
-import docker
 from docker.errors import APIError, ContainerError, ImageLoadError
+from pathlib import PurePosixPath
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from rpdk.core.data_loaders import resource_stream
 from rpdk.core.exceptions import DownstreamError, SysExitRecommendedError
@@ -16,6 +12,9 @@ from rpdk.core.init import input_with_validation
 from rpdk.core.jsonutils.resolver import ContainerType, resolve_models
 from rpdk.core.plugin_base import LanguagePlugin
 from rpdk.core.project import ARTIFACT_TYPE_HOOK
+from subprocess import PIPE, CalledProcessError, run as subprocess_run  # nosec
+from tempfile import TemporaryFile
+from typing import Dict
 
 from . import __version__
 from .resolver import contains_model, translate_type
@@ -318,6 +317,7 @@ class Python36LanguagePlugin(LanguagePlugin):
             LOG.warning(
                 "User ID / Group ID not found.  Using root:root for docker build"
             )
+
 
         docker_client = docker.from_env()
         try:

--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -250,6 +250,17 @@ class Python36LanguagePlugin(LanguagePlugin):
         LOG.debug("Dependencies build finished")
 
     @staticmethod
+    def _update_pip_command():
+        return [
+            "python",
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "pip",
+        ]
+
+    @staticmethod
     def _make_pip_command(base_path):
         return [
             "pip",
@@ -271,7 +282,8 @@ class Python36LanguagePlugin(LanguagePlugin):
     @classmethod
     def _docker_build(cls, external_path):
         internal_path = PurePosixPath("/project")
-        command = " ".join(cls._make_pip_command(internal_path))
+        command = '/bin/bash -c "' + ' '.join(_update_pip_command()) + ' && ' + \
+            ' '.join(_make_pip_command(internal_path)) + '"'
         LOG.debug("command is '%s'", command)
 
         volumes = {str(external_path): {"bind": str(internal_path), "mode": "rw"}}

--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -303,7 +303,7 @@ class Python36LanguagePlugin(LanguagePlugin):
                 volumes=volumes,
                 stream=True,
                 entrypoint="",
-                user=localuser
+                user=localuser,
             )
         except RequestsConnectionError as e:
             # it seems quite hard to reliably extract the cause from

--- a/python/rpdk/python/templates/handlers.py
+++ b/python/rpdk/python/templates/handlers.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Any, MutableMapping, Optional
-
 from {{support_lib_pkg}} import (
     Action,
     HandlerErrorCode,

--- a/python/rpdk/python/templates/hook_handlers.py
+++ b/python/rpdk/python/templates/hook_handlers.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Any, MutableMapping, Optional
-
 from {{support_lib_pkg}} import (
     BaseHookHandlerRequest,
     HandlerErrorCode,

--- a/python/rpdk/python/templates/hook_models.py
+++ b/python/rpdk/python/templates/hook_models.py
@@ -1,6 +1,11 @@
 # DO NOT modify this file by hand, changes will be overwritten
-import sys
 from dataclasses import dataclass
+
+from cloudformation_cli_python_lib.interface import BaseHookHandlerRequest, BaseModel
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+import sys
 from inspect import getmembers, isclass
 from typing import (
     AbstractSet,
@@ -13,10 +18,6 @@ from typing import (
     Type,
     TypeVar,
 )
-
-from cloudformation_cli_python_lib.interface import BaseHookHandlerRequest, BaseModel
-from cloudformation_cli_python_lib.recast import recast_object
-from cloudformation_cli_python_lib.utils import deserialize_list
 
 T = TypeVar("T")
 

--- a/python/rpdk/python/templates/models.py
+++ b/python/rpdk/python/templates/models.py
@@ -1,6 +1,14 @@
 # DO NOT modify this file by hand, changes will be overwritten
-import sys
 from dataclasses import dataclass
+
+from cloudformation_cli_python_lib.interface import (
+    BaseModel,
+    BaseResourceHandlerRequest,
+)
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+import sys
 from inspect import getmembers, isclass
 from typing import (
     AbstractSet,
@@ -13,13 +21,6 @@ from typing import (
     Type,
     TypeVar,
 )
-
-from cloudformation_cli_python_lib.interface import (
-    BaseModel,
-    BaseResourceHandlerRequest,
-)
-from cloudformation_cli_python_lib.recast import recast_object
-from cloudformation_cli_python_lib.utils import deserialize_list
 
 T = TypeVar("T")
 

--- a/python/rpdk/python/templates/target_model.py
+++ b/python/rpdk/python/templates/target_model.py
@@ -1,6 +1,11 @@
 # DO NOT modify this file by hand, changes will be overwritten
-import sys
 from dataclasses import dataclass
+
+from cloudformation_cli_python_lib.interface import BaseModel
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+import sys
 from inspect import getmembers, isclass
 from typing import (
     AbstractSet,
@@ -13,10 +18,6 @@ from typing import (
     Type,
     TypeVar,
 )
-
-from cloudformation_cli_python_lib.interface import BaseModel
-from cloudformation_cli_python_lib.recast import recast_object
-from cloudformation_cli_python_lib.utils import deserialize_list
 
 T = TypeVar("T")
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 """Python 3.6 and 3.7 language support for the CloudFormation CLI"""
 import os.path
 import re
-
 from setuptools import setup
 
 HERE = os.path.abspath(os.path.dirname(__file__))

--- a/src/cloudformation_cli_python_lib/boto3_proxy.py
+++ b/src/cloudformation_cli_python_lib/boto3_proxy.py
@@ -1,7 +1,7 @@
 # boto3 doesn't have stub files
-from typing import Optional
-
 from boto3.session import Session  # type: ignore
+
+from typing import Optional
 
 from .utils import Credentials
 

--- a/src/cloudformation_cli_python_lib/cipher.py
+++ b/src/cloudformation_cli_python_lib/cipher.py
@@ -1,12 +1,10 @@
-import base64
-import json
-import uuid
-from typing import Optional
-
 # boto3, botocore, aws_encryption_sdk don't have stub files
 import boto3  # type: ignore
 
 import aws_encryption_sdk  # type: ignore
+import base64
+import json
+import uuid
 from aws_encryption_sdk.exceptions import AWSEncryptionSDKClientError  # type: ignore
 from aws_encryption_sdk.identifiers import CommitmentPolicy  # type: ignore
 from botocore.client import BaseClient  # type: ignore
@@ -16,6 +14,7 @@ from botocore.credentials import (  # type: ignore
     create_assume_role_refresher,
 )
 from botocore.session import Session, get_session  # type: ignore
+from typing import Optional
 
 from .exceptions import _EncryptionError
 from .utils import Credentials

--- a/src/cloudformation_cli_python_lib/interface.py
+++ b/src/cloudformation_cli_python_lib/interface.py
@@ -1,6 +1,7 @@
 # pylint: disable=invalid-name
-import logging
 from dataclasses import dataclass
+
+import logging
 from enum import Enum, auto
 from typing import Any, List, Mapping, MutableMapping, Optional, Type
 

--- a/src/cloudformation_cli_python_lib/log_delivery.py
+++ b/src/cloudformation_cli_python_lib/log_delivery.py
@@ -24,7 +24,7 @@ class ProviderLogHandler(logging.Handler):
         self.group = group
         self.stream = stream.replace(":", "__")
         self.client = session.client("logs")
-        self.sequence_token = ""
+        self.sequence_token = ""  # nosec
 
     @classmethod
     def _get_existing_logger(cls) -> Optional["ProviderLogHandler"]:

--- a/src/cloudformation_cli_python_lib/metrics.py
+++ b/src/cloudformation_cli_python_lib/metrics.py
@@ -1,8 +1,7 @@
 import datetime
 import logging
-from typing import Any, List, Mapping, Optional, Union
-
 from botocore.exceptions import ClientError  # type: ignore
+from typing import Any, List, Mapping, Optional, Union
 
 from .boto3_proxy import SessionProxy
 from .interface import Action, HookInvocationPoint, MetricTypes, StandardUnit

--- a/src/cloudformation_cli_python_lib/utils.py
+++ b/src/cloudformation_cli_python_lib/utils.py
@@ -1,6 +1,7 @@
 # pylint: disable=invalid-name
-import json
 from dataclasses import dataclass, field, fields
+
+import json
 from datetime import date, datetime, time
 from typing import (
     Any,

--- a/tests/lib/cipher_test.py
+++ b/tests/lib/cipher_test.py
@@ -1,12 +1,11 @@
 # pylint: disable=wrong-import-order,line-too-long
-from unittest.mock import Mock, patch
-
 import pytest
 from cloudformation_cli_python_lib.cipher import KmsCipher
 from cloudformation_cli_python_lib.exceptions import _EncryptionError
 from cloudformation_cli_python_lib.utils import Credentials
 
 from aws_encryption_sdk.exceptions import AWSEncryptionSDKClientError
+from unittest.mock import Mock, patch
 
 
 def mock_session():

--- a/tests/lib/exceptions_test.py
+++ b/tests/lib/exceptions_test.py
@@ -1,8 +1,8 @@
-import importlib
-import inspect
-
 import pytest
 from cloudformation_cli_python_lib.interface import HandlerErrorCode, OperationStatus
+
+import importlib
+import inspect
 
 
 def get_public_exceptions(module_name="cloudformation_cli_python_lib.exceptions"):

--- a/tests/lib/hook_test.py
+++ b/tests/lib/hook_test.py
@@ -1,8 +1,5 @@
 # pylint: disable=redefined-outer-name,protected-access,line-too-long
-import json
 from dataclasses import dataclass
-from datetime import datetime
-from unittest.mock import Mock, call, patch, sentinel
 
 import pytest
 from cloudformation_cli_python_lib import Hook
@@ -22,6 +19,10 @@ from cloudformation_cli_python_lib.interface import (
     ProgressEvent,
 )
 from cloudformation_cli_python_lib.utils import Credentials, HookInvocationRequest
+
+import json
+from datetime import datetime
+from unittest.mock import Mock, call, patch, sentinel
 
 ENTRYPOINT_PAYLOAD = {
     "awsAccountId": "123456789012",

--- a/tests/lib/interface_test.py
+++ b/tests/lib/interface_test.py
@@ -1,7 +1,5 @@
 # pylint: disable=protected-access,redefined-outer-name,abstract-method
-import json
 from dataclasses import dataclass
-from string import ascii_letters
 
 import boto3
 import pytest
@@ -15,7 +13,9 @@ from cloudformation_cli_python_lib.interface import (
 )
 
 import hypothesis.strategies as s  # pylint: disable=C0411
+import json
 from hypothesis import given  # pylint: disable=C0411
+from string import ascii_letters
 
 
 @pytest.fixture(scope="module")

--- a/tests/lib/log_delivery_test.py
+++ b/tests/lib/log_delivery_test.py
@@ -1,8 +1,4 @@
 # pylint: disable=redefined-outer-name,protected-access
-import logging
-from unittest.mock import DEFAULT, Mock, create_autospec, patch
-from uuid import uuid4
-
 import pytest
 from cloudformation_cli_python_lib.log_delivery import (
     HookProviderLogHandler,
@@ -18,6 +14,9 @@ from cloudformation_cli_python_lib.utils import (
 
 import botocore.errorfactory
 import botocore.session
+import logging
+from unittest.mock import DEFAULT, Mock, create_autospec, patch
+from uuid import uuid4
 
 logs_model = botocore.session.get_session().get_service_model("logs")
 factory = botocore.errorfactory.ClientExceptionsFactory()

--- a/tests/lib/metrics_test.py
+++ b/tests/lib/metrics_test.py
@@ -1,8 +1,5 @@
 # auto enums `.name` causes no-member
 # pylint: disable=redefined-outer-name,no-member,protected-access
-from datetime import datetime
-from unittest.mock import Mock, call, patch
-
 import pytest
 from cloudformation_cli_python_lib.interface import (
     Action,
@@ -19,6 +16,8 @@ from cloudformation_cli_python_lib.metrics import (
 
 import botocore.errorfactory
 import botocore.session
+from datetime import datetime
+from unittest.mock import Mock, call, patch
 
 cloudwatch_model = botocore.session.get_session().get_service_model("cloudwatch")
 factory = botocore.errorfactory.ClientExceptionsFactory()
@@ -67,7 +66,7 @@ def test_put_metric_catches_error(mock_session):
     }
 
     with patch(
-        "cloudformation_cli_python_lib.metrics.LOG", auto_spec=True
+        "cloudformation_cli_python_lib.metrics.LOG", autospec=True
     ) as mock_logger:
         publisher.publish_metric(
             MetricTypes.HandlerInvocationCount,
@@ -226,7 +225,7 @@ def test_put_hook_metric_catches_error(mock_session):
     }
 
     with patch(
-        "cloudformation_cli_python_lib.metrics.LOG", auto_spec=True
+        "cloudformation_cli_python_lib.metrics.LOG", autospec=True
     ) as mock_logger:
         publisher.publish_metric(
             MetricTypes.HandlerInvocationCount,

--- a/tests/lib/recast_test.py
+++ b/tests/lib/recast_test.py
@@ -1,7 +1,4 @@
 # pylint: disable=protected-access
-from typing import Awaitable, Generic, Optional, Union
-from unittest.mock import patch
-
 import pytest
 from cloudformation_cli_python_lib.exceptions import InvalidRequest
 from cloudformation_cli_python_lib.recast import (
@@ -11,6 +8,9 @@ from cloudformation_cli_python_lib.recast import (
     get_forward_ref_type,
     recast_object,
 )
+
+from typing import Awaitable, Generic, Optional, Union
+from unittest.mock import patch
 
 from .sample_model import ResourceModel as ComplexResourceModel, SimpleResourceModel
 

--- a/tests/lib/resource_test.py
+++ b/tests/lib/resource_test.py
@@ -1,7 +1,5 @@
 # pylint: disable=redefined-outer-name,protected-access
 from dataclasses import dataclass
-from datetime import datetime
-from unittest.mock import Mock, call, patch, sentinel
 
 import pytest
 from cloudformation_cli_python_lib.exceptions import InternalFailure, InvalidRequest
@@ -14,6 +12,9 @@ from cloudformation_cli_python_lib.interface import (
 )
 from cloudformation_cli_python_lib.resource import Resource, _ensure_serialize
 from cloudformation_cli_python_lib.utils import Credentials, HandlerRequest
+
+from datetime import datetime
+from unittest.mock import Mock, call, patch, sentinel
 
 ENTRYPOINT_PAYLOAD = {
     "awsAccountId": "123456789012",

--- a/tests/lib/sample_model.py
+++ b/tests/lib/sample_model.py
@@ -2,8 +2,16 @@
 # happening as expected
 # pylint: disable=invalid-name, too-many-instance-attributes, protected-access, abstract-method
 
-import sys
 from dataclasses import dataclass
+
+from cloudformation_cli_python_lib.interface import (
+    BaseModel,
+    BaseResourceHandlerRequest,
+)
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+import sys
 from inspect import getmembers, isclass
 from typing import (
     AbstractSet,
@@ -15,13 +23,6 @@ from typing import (
     Type,
     TypeVar,
 )
-
-from cloudformation_cli_python_lib.interface import (
-    BaseModel,
-    BaseResourceHandlerRequest,
-)
-from cloudformation_cli_python_lib.recast import recast_object
-from cloudformation_cli_python_lib.utils import deserialize_list
 
 T = TypeVar("T")
 

--- a/tests/lib/utils_test.py
+++ b/tests/lib/utils_test.py
@@ -1,7 +1,4 @@
 # pylint: disable=protected-access
-import json
-from unittest.mock import Mock, call, sentinel
-
 import pytest
 from cloudformation_cli_python_lib.exceptions import InvalidRequest
 from cloudformation_cli_python_lib.interface import BaseModel
@@ -13,7 +10,9 @@ from cloudformation_cli_python_lib.utils import (
 )
 
 import hypothesis.strategies as s  # pylint: disable=C0411
+import json
 from hypothesis import given  # pylint: disable=C0411
+from unittest.mock import Mock, call, sentinel
 
 
 def roundtrip(value):

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -430,7 +430,7 @@ def test__build_docker_no_euid(plugin):
     patch_from_env = patch("rpdk.python.codegen.docker.from_env", autospec=True)
     patch_os_geteuid = patch("os.geteuid", autospec=True)
 
-    with patch_pip as mock_pip, patch_from_env as mock_from_env, patch_os_geteuid as mock_patch_os_geteuid: # noqa: B950 
+    with patch_pip as mock_pip, patch_from_env as mock_from_env, patch_os_geteuid as mock_patch_os_geteuid:  # noqa: B950 pylint: disable=line-too-long
         mock_run = mock_from_env.return_value.containers.run
         mock_patch_os_geteuid.side_effect = AttributeError()
         plugin._build(sentinel.base_path)

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -430,7 +430,7 @@ def test__build_docker_no_euid(plugin):
     patch_from_env = patch("rpdk.python.codegen.docker.from_env", autospec=True)
     patch_os_geteuid = patch("os.geteuid", autospec=True)
 
-    with patch_pip as mock_pip, patch_from_env as mock_from_env, patch_os_geteuid as mock_patch_os_geteuid:
+    with patch_pip as mock_pip, patch_from_env as mock_from_env, patch_os_geteuid as mock_patch_os_geteuid: # noqa: B950 
         mock_run = mock_from_env.return_value.containers.run
         mock_patch_os_geteuid.side_effect = AttributeError()
         plugin._build(sentinel.base_path)

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -423,6 +423,57 @@ def test__build_docker(plugin):
     mock_docker.assert_called_once_with(sentinel.base_path)
 
 
+# Test _build_docker on Linux/Unix-like systems
+def test__build_docker_posix(plugin):
+    plugin._use_docker = True
+
+    patch_pip = patch.object(plugin, "_pip_build", autospec=True)
+    patch_from_env = patch("rpdk.python.codegen.docker.from_env", autospec=True)
+    patch_os_name = patch("rpdk.python.codegen.os.name", "posix")
+
+    with patch_pip as mock_pip, patch_from_env as mock_from_env:
+        mock_run = mock_from_env.return_value.containers.run
+        with patch_os_name:
+            plugin._build(sentinel.base_path)
+
+    mock_pip.assert_not_called()
+    mock_run.assert_called_once_with(
+        image=ANY,
+        command=ANY,
+        auto_remove=True,
+        volumes={str(sentinel.base_path): {"bind": "/project", "mode": "rw"}},
+        stream=True,
+        entrypoint="",
+        user=ANY,
+    )
+
+
+# Test _build_docker on Windows
+def test__build_docker_windows(plugin):
+    plugin._use_docker = True
+
+    patch_pip = patch.object(plugin, "_pip_build", autospec=True)
+    patch_from_env = patch("rpdk.python.codegen.docker.from_env", autospec=True)
+    patch_os_name = patch("rpdk.python.codegen.os.name", "nt")
+
+    with patch_pip as mock_pip, patch_from_env as mock_from_env:
+        mock_run = mock_from_env.return_value.containers.run
+        with patch_os_name:
+            plugin._build(sentinel.base_path)
+
+    mock_pip.assert_not_called()
+    mock_run.assert_called_once_with(
+        image=ANY,
+        command=ANY,
+        auto_remove=True,
+        volumes={str(sentinel.base_path): {"bind": "/project", "mode": "rw"}},
+        stream=True,
+        entrypoint="",
+        user="root:root",
+    )
+
+
+# Test _build_docker if geteuid fails
 def test__build_docker_no_euid(plugin):
     plugin._use_docker = True
 

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -1,16 +1,10 @@
 # pylint: disable=redefined-outer-name,protected-access
-import ast
-import importlib.util
-from pathlib import Path
-from shutil import copyfile
-from subprocess import CalledProcessError
-from unittest.mock import ANY, patch, sentinel
-from uuid import uuid4
-from zipfile import ZipFile
-
 import pytest
 
+import ast
+import importlib.util
 from docker.errors import APIError, ContainerError, ImageLoadError
+from pathlib import Path
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from rpdk.core.exceptions import DownstreamError
 from rpdk.core.project import Project
@@ -21,6 +15,11 @@ from rpdk.python.codegen import (
     Python36LanguagePlugin as PythonLanguagePlugin,
     validate_no,
 )
+from shutil import copyfile
+from subprocess import CalledProcessError
+from unittest.mock import ANY, patch, sentinel
+from uuid import uuid4
+from zipfile import ZipFile
 
 TYPE_NAME = "foo::bar::baz"
 
@@ -478,6 +477,7 @@ def test__build_docker_no_euid(plugin):
     plugin._use_docker = True
 
     patch_pip = patch.object(plugin, "_pip_build", autospec=True)
+
     patch_from_env = patch("rpdk.python.codegen.docker.from_env", autospec=True)
     patch_os_geteuid = patch("os.geteuid", autospec=True)
 
@@ -488,6 +488,7 @@ def test__build_docker_no_euid(plugin):
 
     mock_pip.assert_not_called()
     mock_run.assert_called_once_with(
+
         image=ANY,
         command=ANY,
         auto_remove=True,

--- a/tests/plugin/parser_test.py
+++ b/tests/plugin/parser_test.py
@@ -1,5 +1,4 @@
 import argparse
-
 from rpdk.python.parser import setup_subparser_python36, setup_subparser_python37
 
 


### PR DESCRIPTION
Closes #100

Docker command to run container was getting the local user euid and gid.  These attributes do not exist on non-UNIX-like OSes like Windows.

Put in check for the command to complete successfully but if not to default to root:root.  Windows ignores these attributes and the Docker file system has built in safeguards around this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
