### PR TITLE
fix(docker): During `cfn submit` docker commands were not working on Windows

### DIFF
--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -422,6 +422,81 @@ def test__build_docker(plugin):
     mock_docker.assert_called_once_with(sentinel.base_path)
 
 
+# Test _build_docker on Linux/Unix-like systems
+def test__build_docker_posix(plugin):
+    plugin._use_docker = True
+
+    patch_pip = patch.object(plugin, "_pip_build", autospec=True)
+    patch_from_env = patch("rpdk.python.codegen.docker.from_env", autospec=True)
+    patch_os_name = patch("rpdk.python.codegen.os.name", "posix")
+
+    with patch_pip as mock_pip, patch_from_env as mock_from_env:
+        mock_run = mock_from_env.return_value.containers.run
+        with patch_os_name:
+            plugin._build(sentinel.base_path)
+
+    mock_pip.assert_not_called()
+    mock_run.assert_called_once_with(
+        image=ANY,
+        command=ANY,
+        auto_remove=True,
+        volumes={str(sentinel.base_path): {"bind": "/project", "mode": "rw"}},
+        stream=True,
+        entrypoint="",
+        user=ANY,
+    )
+
+
+# Test _build_docker on Windows
+def test__build_docker_windows(plugin):
+    plugin._use_docker = True
+
+    patch_pip = patch.object(plugin, "_pip_build", autospec=True)
+    patch_from_env = patch("rpdk.python.codegen.docker.from_env", autospec=True)
+    patch_os_name = patch("rpdk.python.codegen.os.name", "nt")
+
+    with patch_pip as mock_pip, patch_from_env as mock_from_env:
+        mock_run = mock_from_env.return_value.containers.run
+        with patch_os_name:
+            plugin._build(sentinel.base_path)
+
+    mock_pip.assert_not_called()
+    mock_run.assert_called_once_with(
+        image=ANY,
+        command=ANY,
+        auto_remove=True,
+        volumes={str(sentinel.base_path): {"bind": "/project", "mode": "rw"}},
+        stream=True,
+        entrypoint="",
+        user="root:root",
+    )
+
+
+# Test _build_docker if geteuid fails
+def test__build_docker_no_euid(plugin):
+    plugin._use_docker = True
+
+    patch_pip = patch.object(plugin, "_pip_build", autospec=True)
+    patch_from_env = patch("rpdk.python.codegen.docker.from_env", autospec=True)
+    patch_os_geteuid = patch("os.geteuid", autospec=True)
+
+    with patch_pip as mock_pip, patch_from_env as mock_from_env, patch_os_geteuid as mock_patch_os_geteuid:  # noqa: B950 pylint: disable=line-too-long
+        mock_run = mock_from_env.return_value.containers.run
+        mock_patch_os_geteuid.side_effect = AttributeError()
+        plugin._build(sentinel.base_path)
+
+    mock_pip.assert_not_called()
+    mock_run.assert_called_once_with(
+        image=ANY,
+        command=ANY,
+        auto_remove=True,
+        volumes={str(sentinel.base_path): {"bind": "/project", "mode": "rw"}},
+        stream=True,
+        entrypoint="",
+        user="root:root",
+    )
+
+
 def test__docker_build_good_path(plugin, tmp_path):
     patch_from_env = patch("rpdk.python.codegen.docker.from_env", autospec=True)
 


### PR DESCRIPTION
Closes #100 

Docker command to run container was getting the local user euid and gid. These attributes do not exist on non-UNIX-like OSes like Windows.

Put in check for the command to complete successfully but if not to default to root:root. Windows ignores these attributes and the Docker file system has built in safeguards around this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.