### PR TITLE
Revert "fix(test) - Pin importlib to make bandit work"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,8 +51,6 @@ repos:
   hooks:
   - id: bandit
     files: ^(src|python)/
-    additional_dependencies:
-      - "importlib-metadata<5"  # https://github.com/PyCQA/bandit/issues/956
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.812
   hooks:


### PR DESCRIPTION
Reverts aws-cloudformation/cloudformation-cli-python-plugin#202

With the pre-commit updates from #206 this pin no longer looks to be necessary.