### PR TITLE
fix(log): filenotfound exception when `cfn submit` cluttering logs

### DIFF
--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -235,9 +235,9 @@ class Python36LanguagePlugin(LanguagePlugin):
 
     @staticmethod
     def _remove_build_artifacts(deps_path):
-        try:
+        if os.path.exists(deps_path):
             shutil.rmtree(deps_path)
-        except FileNotFoundError:
+        else:
             LOG.debug("'%s' not found, skipping removal", deps_path, exc_info=True)
 
     def _build(self, base_path):

--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -235,10 +235,8 @@ class Python36LanguagePlugin(LanguagePlugin):
 
     @staticmethod
     def _remove_build_artifacts(deps_path):
-        if os.path.exists(deps_path):
-            shutil.rmtree(deps_path)
-        else:
-            LOG.debug("'%s' not found, skipping removal", deps_path, exc_info=True)
+        LOG.debug("Removing '%s' folder.", deps_path)
+        shutil.rmtree(deps_path, ignore_errors=True)
 
     def _build(self, base_path):
         LOG.debug("Dependencies build started from '%s'", base_path)


### PR DESCRIPTION
Closes #212 

switch try/except to if path exists before build path removal


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
