### PR TITLE
fix(docker): update to docker pip update command

### DIFF
--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -313,7 +313,7 @@ class Python36LanguagePlugin(LanguagePlugin):
             + " && "
             + " ".join(cls._make_pip_command(internal_path))
             + " && "
-            + f"chown -R {localuser}"
+            + f"chown -R {localuser} {internal_path}/build"
             + '"'
         )
         LOG.debug("command is '%s'", command)

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -443,7 +443,7 @@ def test__build_docker_posix(plugin):
         volumes={str(sentinel.base_path): {"bind": "/project", "mode": "rw"}},
         stream=True,
         entrypoint="",
-        user=ANY,
+        user="root:root",
     )
 
 
@@ -516,7 +516,7 @@ def test__docker_build_good_path(plugin, tmp_path):
         volumes={str(tmp_path): {"bind": "/project", "mode": "rw"}},
         stream=True,
         entrypoint="",
-        user=ANY,
+        user="root:root",
     )
 
 
@@ -558,5 +558,5 @@ def test__docker_build_bad_path(plugin, tmp_path, exception):
         volumes={str(tmp_path): {"bind": "/project", "mode": "rw"}},
         stream=True,
         entrypoint="",
-        user=ANY,
+        user="root:root",
     )


### PR DESCRIPTION
pip update within lambda container image was failing on mac and linux because it was run as root.  Updated command to run as root and change ownership of the build artifacts directory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
