### PR TITLE
fix(docker): pip upgrade command removed

### DIFF
--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -247,17 +247,6 @@ class Python36LanguagePlugin(LanguagePlugin):
         LOG.debug("Dependencies build finished")
 
     @staticmethod
-    def _update_pip_command():
-        return [
-            "python",
-            "-m",
-            "pip",
-            "install",
-            "--upgrade",
-            "pip",
-        ]
-
-    @staticmethod
     def _make_pip_command(base_path):
         return [
             "pip",
@@ -281,8 +270,6 @@ class Python36LanguagePlugin(LanguagePlugin):
         internal_path = PurePosixPath("/project")
         command = (
             '/bin/bash -c "'
-            + " ".join(cls._update_pip_command())
-            + " && "
             + " ".join(cls._make_pip_command(internal_path))
             + '"'
         )

--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -269,9 +269,7 @@ class Python36LanguagePlugin(LanguagePlugin):
     def _docker_build(cls, external_path):
         internal_path = PurePosixPath("/project")
         command = (
-            '/bin/bash -c "'
-            + " ".join(cls._make_pip_command(internal_path))
-            + '"'
+            '/bin/bash -c "' + " ".join(cls._make_pip_command(internal_path)) + '"'
         )
         LOG.debug("command is '%s'", command)
 


### PR DESCRIPTION
Related to issue #100 

Pip upgrade command removed.  This was causing issues on non-windows machines and was only necessary for Windows machines with cloudformation resources using Python 3.6


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
