### PR TITLE
version bump

### DIFF
--- a/python/rpdk/python/__init__.py
+++ b/python/rpdk/python/__init__.py
@@ -1,5 +1,5 @@
 import logging
 
-__version__ = "2.1.5"
+__version__ = "2.1.6"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     zip_safe=True,
     python_requires=">=3.6",
-    install_requires=["cloudformation-cli>=0.2.23", "types-dataclasses>=0.1.5"],
+    install_requires=["cloudformation-cli>=0.2.26", "types-dataclasses>=0.1.5"],
     entry_points={
         "rpdk.v1.languages": [
             "python37 = rpdk.python.codegen:Python37LanguagePlugin",

--- a/src/setup.py
+++ b/src/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="cloudformation-cli-python-lib",
-    version="2.1.13a1",
+    version="2.1.13",
     description=__doc__,
     author="Amazon Web Services",
     author_email="aws-cloudformation-developers@amazon.com",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Incrementing a version for both plugin and library (`v2.1.6` and `v2.1.13`);
Plugin setup requires a cli dependency. With the latest release of [v0.2.26](https://pypi.org/project/cloudformation-cli/0.2.26/) install requirement has to be adjusted. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
