### PR TITLE
switch auto_remove with remove in codegen and tests

### DIFF
--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -306,7 +306,7 @@ class Python36LanguagePlugin(LanguagePlugin):
             logs = docker_client.containers.run(
                 image=image,
                 command=command,
-                auto_remove=True,
+                remove=True,
                 volumes=volumes,
                 stream=True,
                 entrypoint="",

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -445,7 +445,7 @@ def test__build_docker_posix(plugin):
     mock_run.assert_called_once_with(
         image=ANY,
         command=ANY,
-        auto_remove=True,
+        remove=True,
         volumes={str(sentinel.base_path): {"bind": "/project", "mode": "rw"}},
         stream=True,
         entrypoint="",
@@ -470,7 +470,7 @@ def test__build_docker_windows(plugin):
     mock_run.assert_called_once_with(
         image=ANY,
         command=ANY,
-        auto_remove=True,
+        remove=True,
         volumes={str(sentinel.base_path): {"bind": "/project", "mode": "rw"}},
         stream=True,
         entrypoint="",
@@ -498,7 +498,7 @@ def test__build_docker_no_euid(plugin):
     mock_run.assert_called_once_with(
         image=ANY,
         command=ANY,
-        auto_remove=True,
+        remove=True,
         volumes={str(sentinel.base_path): {"bind": "/project", "mode": "rw"}},
         stream=True,
         entrypoint="",
@@ -518,7 +518,7 @@ def test__docker_build_good_path(plugin, tmp_path):
     mock_run.assert_called_once_with(
         image=ANY,
         command=ANY,
-        auto_remove=True,
+        remove=True,
         volumes={str(tmp_path): {"bind": "/project", "mode": "rw"}},
         stream=True,
         entrypoint="",
@@ -560,7 +560,7 @@ def test__docker_build_bad_path(plugin, tmp_path, exception):
     mock_run.assert_called_once_with(
         image=ANY,
         command=ANY,
-        auto_remove=True,
+        remove=True,
         volumes={str(tmp_path): {"bind": "/project", "mode": "rw"}},
         stream=True,
         entrypoint="",


### PR DESCRIPTION
Closes #211 

Use docker container.run remove option instead of auto_remove. If the job errors, this will allow the user to run the container outside the run and troubleshoot further.  This will also mean on error manual cleanup of the containers would be necessary.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
