### PR TITLE
Add UnsupportedTarget error code

### DIFF
--- a/src/cloudformation_cli_python_lib/exceptions.py
+++ b/src/cloudformation_cli_python_lib/exceptions.py
@@ -96,6 +96,14 @@ class NonCompliant(_HandlerError):
         )
 
 
+class UnsupportedTarget(_HandlerError):
+    def __init__(self, hook_type_name: str, target_type_name: str):
+        super().__init__(
+            f"Hook of type '{hook_type_name}' received request"
+            f" for unsupported target '{target_type_name}'"
+        )
+
+
 class Unknown(_HandlerError):
     pass
 

--- a/src/cloudformation_cli_python_lib/interface.py
+++ b/src/cloudformation_cli_python_lib/interface.py
@@ -73,6 +73,7 @@ class HandlerErrorCode(str, _AutoName):
     InvalidTypeConfiguration = auto()
     HandlerInternalFailure = auto()
     NonCompliant = auto()
+    UnsupportedTarget = auto()
     Unknown = auto()
 
 


### PR DESCRIPTION
This PR adds a `UnsupportedTarget` error code.

Related PR: https://github.com/aws-cloudformation/cloudformation-cli/pull/945

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
