### PR TITLE
fix(submit): Switch to ECR SAM build python container image

### DIFF
--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -274,7 +274,7 @@ class Python36LanguagePlugin(LanguagePlugin):
         LOG.debug("command is '%s'", command)
 
         volumes = {str(external_path): {"bind": str(internal_path), "mode": "rw"}}
-        image = f"public.ecr.aws/lambda/python:{cls.DOCKER_TAG}"
+        image = f"public.ecr.aws/sam/build-python{cls.DOCKER_TAG}"
         LOG.warning(
             "Starting Docker build. This may take several minutes if the "
             "image '%s' needs to be pulled first.",


### PR DESCRIPTION
Closes #228 #229 

Lambda image is missing git/ssh/svn switching to SAM python build image instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
