### PR TITLE
chore(unittests): if not defined set a default region in boto3_proxy.py

### DIFF
--- a/src/cloudformation_cli_python_lib/boto3_proxy.py
+++ b/src/cloudformation_cli_python_lib/boto3_proxy.py
@@ -14,7 +14,7 @@ class SessionProxy:
 
 
 def _get_boto_session(
-    credentials: Optional[Credentials], region: Optional[str] = None
+    credentials: Optional[Credentials], region: Optional[str] = "us-east-1"
 ) -> Optional[SessionProxy]:
     if not credentials:
         return None

--- a/src/cloudformation_cli_python_lib/boto3_proxy.py
+++ b/src/cloudformation_cli_python_lib/boto3_proxy.py
@@ -16,7 +16,7 @@ class SessionProxy:
 def _get_boto_session(
     credentials: Optional[Credentials], region: Optional[str] = "us-east-1"
 ) -> Optional[SessionProxy]:
-    if not credentials:
+    if not credentials or not region:
         return None
     session = Session(
         aws_access_key_id=credentials.accessKeyId,

--- a/tests/lib/boto3_proxy_test.py
+++ b/tests/lib/boto3_proxy_test.py
@@ -3,13 +3,23 @@ from cloudformation_cli_python_lib.boto3_proxy import SessionProxy, _get_boto_se
 from cloudformation_cli_python_lib.utils import Credentials
 
 
-def test_get_boto_session_returns_proxy():
+def test_get_boto_session_region_returns_proxy():
+    proxy = _get_boto_session(Credentials("", "", ""), region="test-region")
+    assert isinstance(proxy, SessionProxy)
+
+
+def test_get_boto_session_no_region_returns_proxy():
     proxy = _get_boto_session(Credentials("", "", ""))
     assert isinstance(proxy, SessionProxy)
 
 
 def test_get_boto_session_returns_none():
     proxy = _get_boto_session(None)
+    assert proxy is None
+
+
+def test_get_boto_no_session_no_region_returns_none():
+    proxy = _get_boto_session(None, None)
     assert proxy is None
 
 


### PR DESCRIPTION
Closes #219 

Unit tests do not require AWS credentials but were still failing if no region was set.  Set default region in boto3_proxy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
