### PR TITLE
fix(submit) - pip build on windows command causing unintended consequence on posix

### DIFF
--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -334,14 +334,24 @@ class Python36LanguagePlugin(LanguagePlugin):
 
         LOG.warning("Starting pip build.")
         try:
-            completed_proc = subprocess_run(  # nosec
-                command,
-                stdout=PIPE,
-                stderr=PIPE,
-                cwd=base_path,
-                check=True,
-                shell=True,
-            )
+            # On windows run pip command through the default shell (CMD)
+            if os.name == "nt":
+                completed_proc = subprocess_run(  # nosec
+                    command,
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    cwd=base_path,
+                    check=True,
+                    shell=True,
+                )
+            else:
+                completed_proc = subprocess_run(  # nosec
+                    command,
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    cwd=base_path,
+                    check=True,
+                )
             LOG.warning("pip build finished.")
         except (FileNotFoundError, CalledProcessError) as e:
             raise DownstreamError("pip build failed") from e

--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -335,7 +335,7 @@ class Python36LanguagePlugin(LanguagePlugin):
         LOG.warning("Starting pip build.")
         try:
             # On windows run pip command through the default shell (CMD)
-            if os.name == "nt":  # pragma: no cover
+            if os.name == "nt":
                 completed_proc = subprocess_run(  # nosec
                     command,
                     stdout=PIPE,

--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -335,7 +335,7 @@ class Python36LanguagePlugin(LanguagePlugin):
         LOG.warning("Starting pip build.")
         try:
             # On windows run pip command through the default shell (CMD)
-            if os.name == "nt":
+            if os.name == "nt":  # pragma: no cover
                 completed_proc = subprocess_run(  # nosec
                     command,
                     stdout=PIPE,

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -416,6 +416,43 @@ def test__build_pip(plugin):
     mock_pip.assert_called_once_with(sentinel.base_path)
 
 
+def test__build_pip_posix(plugin):
+    patch_os_name = patch("rpdk.python.codegen.os.name", "posix")
+    patch_subproc = patch("rpdk.python.codegen.subprocess_run")
+
+    # Path must be set outside simulated os.name
+    temppath = Path(str(sentinel.base_path))
+    with patch_os_name, patch_subproc as mock_subproc:  # noqa: B950 pylint: disable=line-too-long
+        plugin._pip_build(temppath)
+
+    mock_subproc.assert_called_once_with(
+        plugin._make_pip_command(temppath),
+        stdout=ANY,
+        stderr=ANY,
+        cwd=temppath,
+        check=ANY,
+    )
+
+
+def test__build_pip_windows(plugin):
+    patch_os_name = patch("rpdk.python.codegen.os.name", "nt")
+    patch_subproc = patch("rpdk.python.codegen.subprocess_run")
+
+    # Path must be set outside simulated os.name
+    temppath = Path(str(sentinel.base_path))
+    with patch_os_name, patch_subproc as mock_subproc:  # noqa: B950 pylint: disable=line-too-long
+        plugin._pip_build(temppath)
+
+    mock_subproc.assert_called_once_with(
+        plugin._make_pip_command(temppath),
+        stdout=ANY,
+        stderr=ANY,
+        cwd=temppath,
+        check=ANY,
+        shell=True,
+    )
+
+
 def test__build_docker(plugin):
     plugin._use_docker = True
 

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -422,7 +422,7 @@ def test__build_pip_posix(plugin):
 
     # Path must be set outside simulated os.name
     temppath = Path(str(sentinel.base_path))
-    with patch_os_name, patch_subproc as mock_subproc:  # noqa: B950 pylint: disable=line-too-long
+    with patch_os_name, patch_subproc as mock_subproc:
         plugin._pip_build(temppath)
 
     mock_subproc.assert_called_once_with(
@@ -440,7 +440,7 @@ def test__build_pip_windows(plugin):
 
     # Path must be set outside simulated os.name
     temppath = Path(str(sentinel.base_path))
-    with patch_os_name, patch_subproc as mock_subproc:  # noqa: B950 pylint: disable=line-too-long
+    with patch_os_name, patch_subproc as mock_subproc:
         plugin._pip_build(temppath)
 
     mock_subproc.assert_called_once_with(


### PR DESCRIPTION
Closes #235 

Non docker - python requirements build on Windows requires shell parameter for subprocess.run.  This causes non-docker builds on POSIX systems to not gather dependencies.  Changed to use altered statement only on windows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
