### PR TITLE
If desired resource state/tag is none, default to empty dictionary

### DIFF
--- a/src/cloudformation_cli_python_lib/resource.py
+++ b/src/cloudformation_cli_python_lib/resource.py
@@ -164,9 +164,9 @@ class Resource:
         try:
             return UnmodelledRequest(
                 clientRequestToken=request.bearerToken,
-                desiredResourceState=request.requestData.resourceProperties,
+                desiredResourceState=request.requestData.resourceProperties if request.requestData.resourceProperties else {},
                 previousResourceState=request.requestData.previousResourceProperties,
-                desiredResourceTags=request.requestData.stackTags,
+                desiredResourceTags=request.requestData.stackTags if request.requestData.stackTags else {},
                 previousResourceTags=request.requestData.previousStackTags,
                 systemTags=request.requestData.systemTags,
                 previousSystemTags=request.requestData.previousSystemTags,

--- a/src/cloudformation_cli_python_lib/resource.py
+++ b/src/cloudformation_cli_python_lib/resource.py
@@ -164,9 +164,13 @@ class Resource:
         try:
             return UnmodelledRequest(
                 clientRequestToken=request.bearerToken,
-                desiredResourceState=request.requestData.resourceProperties if request.requestData.resourceProperties else {},
+                desiredResourceState=request.requestData.resourceProperties
+                if request.requestData.resourceProperties
+                else {},
                 previousResourceState=request.requestData.previousResourceProperties,
-                desiredResourceTags=request.requestData.stackTags if request.requestData.stackTags else {},
+                desiredResourceTags=request.requestData.stackTags
+                if request.requestData.stackTags
+                else {},
                 previousResourceTags=request.requestData.previousStackTags,
                 systemTags=request.requestData.systemTags,
                 previousSystemTags=request.requestData.previousSystemTags,


### PR DESCRIPTION
Closes #230 

If desiredResourceState or desiredResourceTags is empty then default to empty dictionary instead of None.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
