### PR TITLE
Update unit test to mock boto3 session

### DIFF
--- a/tests/lib/hook_test.py
+++ b/tests/lib/hook_test.py
@@ -85,7 +85,7 @@ def test_entrypoint_success():
         Mock(return_value=event)
     )
 
-    with patch(
+    with patch("cloudformation_cli_python_lib.hook._get_boto_session"), patch(
         "cloudformation_cli_python_lib.hook.HookProviderLogHandler.setup"
     ) as mock_log_delivery, patch(
         "cloudformation_cli_python_lib.hook.KmsCipher.decrypt_credentials"
@@ -154,7 +154,7 @@ def test_entrypoint_with_context():
         Mock(return_value=event)
     )
 
-    with patch(
+    with patch("cloudformation_cli_python_lib.hook._get_boto_session"), patch(
         "cloudformation_cli_python_lib.hook.HookProviderLogHandler.setup"
     ), patch(
         "cloudformation_cli_python_lib.hook.KmsCipher.decrypt_credentials"

--- a/tests/lib/resource_test.py
+++ b/tests/lib/resource_test.py
@@ -82,7 +82,7 @@ def test_entrypoint_success():
     event = ProgressEvent(status=OperationStatus.SUCCESS, message="")
     mock_handler = resource.handler(Action.CREATE)(Mock(return_value=event))
 
-    with patch(
+    with patch("cloudformation_cli_python_lib.resource._get_boto_session"), patch(
         "cloudformation_cli_python_lib.resource.ProviderLogHandler.setup"
     ) as mock_log_delivery:
         event = resource.__call__.__wrapped__(  # pylint: disable=no-member
@@ -164,7 +164,9 @@ def test_entrypoint_with_context():
     )
     mock_handler = resource.handler(Action.CREATE)(Mock(return_value=event))
 
-    with patch("cloudformation_cli_python_lib.resource.ProviderLogHandler.setup"):
+    with patch("cloudformation_cli_python_lib.resource._get_boto_session"), patch(
+        "cloudformation_cli_python_lib.resource.ProviderLogHandler.setup"
+    ):
         resource.__call__.__wrapped__(  # pylint: disable=no-member
             resource, payload, None
         )
@@ -179,7 +181,7 @@ def test_entrypoint_ignore_remove_fields_from_response():
     )
     mock_handler = resource.handler(Action.CREATE)(Mock(return_value=event))
 
-    with patch(
+    with patch("cloudformation_cli_python_lib.resource._get_boto_session"), patch(
         "cloudformation_cli_python_lib.resource.ProviderLogHandler.setup"
     ) as mock_log_delivery:
         event = resource.__call__.__wrapped__(  # pylint: disable=no-member


### PR DESCRIPTION
Closes #219, #232 

Update unit tests for hook/resource to mock the boto3 session.  This way no environment variables nor credentials files need to be populated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
