### PR TITLE
Generate models for hook targets

### DIFF
--- a/python/rpdk/python/templates/target_model.py
+++ b/python/rpdk/python/templates/target_model.py
@@ -43,12 +43,8 @@ class {{ model }}(BaseModel):
         if not json_data:
             return None
         {% if model == (target_name) %}
-        data = dict(filter(lambda e: e[0] in cls.__dataclass_fields__, json_data.items()))
-        if not data:
-            return None
-
         dataclasses = {n: o for n, o in getmembers(sys.modules[__name__]) if isclass(o)}
-        recast_object(cls, data, dataclasses)
+        recast_object(cls, json_data, dataclasses)
         {% endif %}
         return cls(
             {% for name, type in properties.items() %}

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -415,6 +415,9 @@ def test_generate_hook(hook_project):
     print("Project files: ", get_files_in_project(hook_project))
     assert files == {
         f"{os.path.join('src', 'foo_bar_baz', 'models.py')}",
+        f"{os.path.join('src', 'foo_bar_baz', 'target_models')}",
+        f"{os.path.join('src', 'foo_bar_baz', 'target_models', 'my_example_resource.py')}",  # noqa: B950 pylint: disable=line-too-long
+        f"{os.path.join('src', 'foo_bar_baz', 'target_models', 'my_other_resource.py')}",  # noqa: B950 pylint: disable=line-too-long
         "foo-bar-baz-configuration.json",
     }
 


### PR DESCRIPTION

*Description of changes:*

Running `cfn generate` will now generate Python models for HOOK targets

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
