### PR TITLE
udpate docker run to force platform to linux/amd64

### DIFF
--- a/python/rpdk/python/codegen.py
+++ b/python/rpdk/python/codegen.py
@@ -375,6 +375,7 @@ class Python36LanguagePlugin(LanguagePlugin):
                 stream=True,
                 entrypoint="",
                 user=localuser,
+                platform="linux/amd64",
             )
         except RequestsConnectionError as e:
             # it seems quite hard to reliably extract the cause from

--- a/tests/plugin/codegen_test.py
+++ b/tests/plugin/codegen_test.py
@@ -626,6 +626,7 @@ def test__build_docker_posix(plugin):
         stream=True,
         entrypoint="",
         user=ANY,
+        platform="linux/amd64",
     )
 
 
@@ -652,6 +653,7 @@ def test__build_docker_windows(plugin):
         stream=True,
         entrypoint="",
         user="root:root",
+        platform="linux/amd64",
     )
 
 
@@ -681,6 +683,7 @@ def test__build_docker_no_euid(plugin):
         stream=True,
         entrypoint="",
         user="root:root",
+        platform="linux/amd64",
     )
 
 
@@ -701,6 +704,7 @@ def test__docker_build_good_path(plugin, tmp_path):
         stream=True,
         entrypoint="",
         user=ANY,
+        platform="linux/amd64",
     )
 
 
@@ -743,4 +747,5 @@ def test__docker_build_bad_path(plugin, tmp_path, exception):
         stream=True,
         entrypoint="",
         user=ANY,
+        platform="linux/amd64",
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update docker run to force platform to `linux/amd64`


On Mac OS with the M1 chips docker run will use ARM which results in python packages that have binaries pulling down the aarch based binaries.  This will force docker to use a linux/amd64 image so we get the right binaries downloaded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
