### PR TITLE
Pin to lower version of cryptography

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -16,6 +16,7 @@ setup(
     install_requires=[
         "boto3>=1.10.20",
         "aws-encryption-sdk==3.1.0",
+        "cryptography<40.0.0",
         'dataclasses;python_version<"3.7"',
     ],
     license="Apache License 2.0",


### PR DESCRIPTION
Closes #253 

Newest version of python cryptography breaks contract testing.  Pinning to lower version of cryptography.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
