### PR TITLE
Bump version of encryption sdk to remove cryptography pinning

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -15,8 +15,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "boto3>=1.10.20",
-        "aws-encryption-sdk==3.1.0",
-        "cryptography<40.0.0",
+        "aws-encryption-sdk==3.1.1",
         'dataclasses;python_version<"3.7"',
     ],
     license="Apache License 2.0",


### PR DESCRIPTION
*Issue #, if available:* #255

*Description of changes:*

A previous commit pinned the version of `cryptography` to `<40.0.0` to resolve incompatibility between the version of the `aws-encryption-sdk` being used with this project and the latest `cryptography` library. However, this package has no direct dependency on `cryptography` and the `aws-encryption-sdk` fixed their compatibility issue with a patch version bump in `3.1.1`, so we should use that patch version instead of pinning to an older version of a downstream dependency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
