### PR TITLE
Create pypi-release.yaml

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -1,0 +1,27 @@
+# This workflow will release project to PyPI
+name: CloudFormation CLI Python Plugin Release
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  build:
+    if: endsWith(github.ref, '-plugin')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.11
+    - name: Install dependencies
+      run: |
+        pip install --upgrade wheel twine
+    - name: Package project
+      run: |
+        python setup.py sdist bdist_wheel
+    - name: Publish distribution 📦 to PyPI (If triggered from release)
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_KEY_CLOUDFORMATION_CLI_PYTHON_PLUGIN  }}


### PR DESCRIPTION
This helps in automating the PyPi release when the package version is bumped.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
